### PR TITLE
[Setting/#2] 공유 패키지 기반 구축

### DIFF
--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -1,0 +1,58 @@
+import type { ApiResponse } from "@shinhanqna/types";
+
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    public resultCode: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+interface FetchOptions extends Omit<RequestInit, "body"> {
+  body?: unknown;
+}
+
+export async function apiFetch<T>(
+  path: string,
+  options: FetchOptions = {},
+): Promise<T> {
+  const { body, headers: customHeaders, ...rest } = options;
+
+  const headers: Record<string, string> = {
+    ...(customHeaders as Record<string, string>),
+  };
+
+  let fetchBody: BodyInit | undefined;
+
+  if (body instanceof FormData) {
+    fetchBody = body;
+  } else if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+    fetchBody = JSON.stringify(body);
+  }
+
+  const res = await fetch(path, {
+    ...rest,
+    headers,
+    body: fetchBody,
+  });
+
+  if (!res.ok) {
+    let resultCode = "UNKNOWN";
+    let msg = res.statusText;
+
+    try {
+      const errorData: ApiResponse<unknown> = await res.json();
+      resultCode = errorData.resultCode;
+      msg = errorData.msg;
+    } catch {}
+
+    throw new ApiError(res.status, resultCode, msg);
+  }
+
+  const json: ApiResponse<T> = await res.json();
+  return json.data;
+}

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -53,6 +53,15 @@ export async function apiFetch<T>(
     throw new ApiError(res.status, resultCode, msg);
   }
 
+  if (res.status === 204 || res.headers.get("content-length") === "0") {
+    return undefined as T;
+  }
+
   const json: ApiResponse<T> = await res.json();
+
+  if (!("data" in json)) {
+    throw new ApiError(res.status, "MALFORMED_RESPONSE", "Unexpected response shape");
+  }
+
   return json.data;
 }

--- a/packages/api/src/endpoints/admin.ts
+++ b/packages/api/src/endpoints/admin.ts
@@ -1,0 +1,36 @@
+import type { PaginatedData, AdminPostReportItem, AdminCommentReportItem } from "@shinhanqna/types";
+import { apiFetch } from "../client";
+
+export const adminKeys = {
+  all: ["admin"] as const,
+  postReports: (page?: number) => [...adminKeys.all, "postReports", { page }] as const,
+  commentReports: (page?: number) => [...adminKeys.all, "commentReports", { page }] as const,
+};
+
+export function fetchPostReports(params: { page?: number; size?: number }) {
+  const searchParams = new URLSearchParams();
+  if (params.page !== undefined) searchParams.set("page", String(params.page));
+  if (params.size !== undefined) searchParams.set("size", String(params.size));
+
+  return apiFetch<PaginatedData<AdminPostReportItem>>(`/api/admin/reports/posts?${searchParams}`);
+}
+
+export function fetchCommentReports(params: { page?: number; size?: number }) {
+  const searchParams = new URLSearchParams();
+  if (params.page !== undefined) searchParams.set("page", String(params.page));
+  if (params.size !== undefined) searchParams.set("size", String(params.size));
+
+  return apiFetch<PaginatedData<AdminCommentReportItem>>(`/api/admin/reports/comments?${searchParams}`);
+}
+
+export function adminDeletePost(postId: number) {
+  return apiFetch<void>(`/api/admin/posts/${postId}`, {
+    method: "DELETE",
+  });
+}
+
+export function adminDeleteComment(commentId: number) {
+  return apiFetch<void>(`/api/admin/comments/${commentId}`, {
+    method: "DELETE",
+  });
+}

--- a/packages/api/src/endpoints/admin.ts
+++ b/packages/api/src/endpoints/admin.ts
@@ -3,8 +3,10 @@ import { apiFetch } from "../client";
 
 export const adminKeys = {
   all: ["admin"] as const,
-  postReports: (page?: number) => [...adminKeys.all, "postReports", { page }] as const,
-  commentReports: (page?: number) => [...adminKeys.all, "commentReports", { page }] as const,
+  postReportsList: () => [...adminKeys.all, "postReports"] as const,
+  postReports: (page?: number, size?: number) => [...adminKeys.postReportsList(), { page, size }] as const,
+  commentReportsList: () => [...adminKeys.all, "commentReports"] as const,
+  commentReports: (page?: number, size?: number) => [...adminKeys.commentReportsList(), { page, size }] as const,
 };
 
 export function fetchPostReports(params: { page?: number; size?: number }) {

--- a/packages/api/src/endpoints/auth.ts
+++ b/packages/api/src/endpoints/auth.ts
@@ -1,0 +1,30 @@
+import type { TokenPair, LoginRequest, RegisterRequest, RefreshTokenRequest, LogoutRequest } from "@shinhanqna/types";
+import { apiFetch } from "../client";
+
+export function login(data: LoginRequest) {
+  return apiFetch<TokenPair>("/api/auth/login", {
+    method: "POST",
+    body: data,
+  });
+}
+
+export function register(data: RegisterRequest) {
+  return apiFetch<void>("/api/auth/register", {
+    method: "POST",
+    body: data,
+  });
+}
+
+export function refresh(data: RefreshTokenRequest) {
+  return apiFetch<TokenPair>("/api/auth/refresh", {
+    method: "POST",
+    body: data,
+  });
+}
+
+export function logout(data: LogoutRequest) {
+  return apiFetch<void>("/api/auth/logout", {
+    method: "POST",
+    body: data,
+  });
+}

--- a/packages/api/src/endpoints/comments.ts
+++ b/packages/api/src/endpoints/comments.ts
@@ -1,0 +1,31 @@
+import type { CommentListResponse, CommentCreateRequest, CommentUpdateRequest, CommentCreateResponse } from "@shinhanqna/types";
+import { apiFetch } from "../client";
+
+export const commentKeys = {
+  all: ["comments"] as const,
+  list: (postId: number) => [...commentKeys.all, "list", postId] as const,
+};
+
+export function fetchComments(postId: number) {
+  return apiFetch<CommentListResponse>(`/api/posts/${postId}/comments`);
+}
+
+export function createComment(postId: number, data: CommentCreateRequest) {
+  return apiFetch<CommentCreateResponse>(`/api/posts/${postId}/comments`, {
+    method: "POST",
+    body: data,
+  });
+}
+
+export function updateComment(postId: number, commentId: number, data: CommentUpdateRequest) {
+  return apiFetch<void>(`/api/posts/${postId}/comments/${commentId}`, {
+    method: "PATCH",
+    body: data,
+  });
+}
+
+export function deleteComment(postId: number, commentId: number) {
+  return apiFetch<void>(`/api/posts/${postId}/comments/${commentId}`, {
+    method: "DELETE",
+  });
+}

--- a/packages/api/src/endpoints/likes.ts
+++ b/packages/api/src/endpoints/likes.ts
@@ -1,0 +1,8 @@
+import type { LikeToggleResponse } from "@shinhanqna/types";
+import { apiFetch } from "../client";
+
+export function toggleLike(postId: number) {
+  return apiFetch<LikeToggleResponse>(`/api/posts/${postId}/likes`, {
+    method: "POST",
+  });
+}

--- a/packages/api/src/endpoints/members.ts
+++ b/packages/api/src/endpoints/members.ts
@@ -1,0 +1,9 @@
+import type { NicknameUpdateRequest } from "@shinhanqna/types";
+import { apiFetch } from "../client";
+
+export function updateNickname(data: NicknameUpdateRequest) {
+  return apiFetch<void>("/api/members/me/nickname", {
+    method: "PATCH",
+    body: data,
+  });
+}

--- a/packages/api/src/endpoints/posts.ts
+++ b/packages/api/src/endpoints/posts.ts
@@ -1,0 +1,50 @@
+import type { BoardType, PostDetail, PostCreateRequest, PostUpdateRequest, PaginatedData } from "@shinhanqna/types";
+import { apiFetch } from "../client";
+
+export const postKeys = {
+  all: ["posts"] as const,
+  lists: () => [...postKeys.all, "list"] as const,
+  list: (boardType?: BoardType, page?: number) => [...postKeys.lists(), { boardType, page }] as const,
+  details: () => [...postKeys.all, "detail"] as const,
+  detail: (postId: number) => [...postKeys.details(), postId] as const,
+};
+
+export function fetchPosts(params: { boardType?: BoardType; page?: number; size?: number }) {
+  const searchParams = new URLSearchParams();
+  if (params.boardType) searchParams.set("boardType", params.boardType);
+  if (params.page !== undefined) searchParams.set("page", String(params.page));
+  if (params.size !== undefined) searchParams.set("size", String(params.size));
+
+  return apiFetch<PaginatedData<PostDetail>>(`/api/posts?${searchParams}`);
+}
+
+export function fetchPost(postId: number) {
+  return apiFetch<PostDetail>(`/api/posts/${postId}`);
+}
+
+export function createPost(data: PostCreateRequest, images?: File[]) {
+  const formData = new FormData();
+  formData.append("post", new Blob([JSON.stringify(data)], { type: "application/json" }));
+
+  if (images) {
+    images.forEach((file) => formData.append("images", file));
+  }
+
+  return apiFetch<{ postId: number }>("/api/posts", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+export function updatePost(postId: number, data: PostUpdateRequest) {
+  return apiFetch<void>(`/api/posts/${postId}`, {
+    method: "PATCH",
+    body: data,
+  });
+}
+
+export function deletePost(postId: number) {
+  return apiFetch<void>(`/api/posts/${postId}`, {
+    method: "DELETE",
+  });
+}

--- a/packages/api/src/endpoints/posts.ts
+++ b/packages/api/src/endpoints/posts.ts
@@ -23,6 +23,10 @@ export function fetchPost(postId: number) {
 }
 
 export function createPost(data: PostCreateRequest, images?: File[]) {
+  if (images && images.length > 5) {
+    throw new Error("이미지는 최대 5장까지 첨부할 수 있습니다.");
+  }
+
   const formData = new FormData();
   formData.append("post", new Blob([JSON.stringify(data)], { type: "application/json" }));
 

--- a/packages/api/src/endpoints/posts.ts
+++ b/packages/api/src/endpoints/posts.ts
@@ -4,7 +4,7 @@ import { apiFetch } from "../client";
 export const postKeys = {
   all: ["posts"] as const,
   lists: () => [...postKeys.all, "list"] as const,
-  list: (boardType?: BoardType, page?: number) => [...postKeys.lists(), { boardType, page }] as const,
+  list: (boardType?: BoardType, page?: number, size?: number) => [...postKeys.lists(), { boardType, page, size }] as const,
   details: () => [...postKeys.all, "detail"] as const,
   detail: (postId: number) => [...postKeys.details(), postId] as const,
 };

--- a/packages/api/src/endpoints/reports.ts
+++ b/packages/api/src/endpoints/reports.ts
@@ -1,0 +1,16 @@
+import type { ReportCreateRequest, ReportCreateResponse } from "@shinhanqna/types";
+import { apiFetch } from "../client";
+
+export function reportPost(postId: number, data: ReportCreateRequest) {
+  return apiFetch<ReportCreateResponse>(`/api/posts/${postId}/reports`, {
+    method: "POST",
+    body: data,
+  });
+}
+
+export function reportComment(commentId: number, data: ReportCreateRequest) {
+  return apiFetch<ReportCreateResponse>(`/api/comments/${commentId}/reports`, {
+    method: "POST",
+    body: data,
+  });
+}

--- a/packages/api/src/hooks/use-admin.ts
+++ b/packages/api/src/hooks/use-admin.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { adminKeys, fetchPostReports, fetchCommentReports, adminDeletePost, adminDeleteComment } from "../endpoints/admin";
+
+export function usePostReports(page = 0, size = 20) {
+  return useQuery({
+    queryKey: adminKeys.postReports(page),
+    queryFn: () => fetchPostReports({ page, size }),
+  });
+}
+
+export function useCommentReports(page = 0, size = 20) {
+  return useQuery({
+    queryKey: adminKeys.commentReports(page),
+    queryFn: () => fetchCommentReports({ page, size }),
+  });
+}
+
+export function useAdminDeletePost() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (postId: number) => adminDeletePost(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.postReports() });
+    },
+  });
+}
+
+export function useAdminDeleteComment() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (commentId: number) => adminDeleteComment(commentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: adminKeys.commentReports() });
+    },
+  });
+}

--- a/packages/api/src/hooks/use-admin.ts
+++ b/packages/api/src/hooks/use-admin.ts
@@ -5,14 +5,14 @@ import { adminKeys, fetchPostReports, fetchCommentReports, adminDeletePost, admi
 
 export function usePostReports(page = 0, size = 20) {
   return useQuery({
-    queryKey: adminKeys.postReports(page),
+    queryKey: adminKeys.postReports(page, size),
     queryFn: () => fetchPostReports({ page, size }),
   });
 }
 
 export function useCommentReports(page = 0, size = 20) {
   return useQuery({
-    queryKey: adminKeys.commentReports(page),
+    queryKey: adminKeys.commentReports(page, size),
     queryFn: () => fetchCommentReports({ page, size }),
   });
 }
@@ -22,7 +22,7 @@ export function useAdminDeletePost() {
   return useMutation({
     mutationFn: (postId: number) => adminDeletePost(postId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: adminKeys.postReports() });
+      queryClient.invalidateQueries({ queryKey: adminKeys.postReportsList() });
     },
   });
 }
@@ -32,7 +32,7 @@ export function useAdminDeleteComment() {
   return useMutation({
     mutationFn: (commentId: number) => adminDeleteComment(commentId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: adminKeys.commentReports() });
+      queryClient.invalidateQueries({ queryKey: adminKeys.commentReportsList() });
     },
   });
 }

--- a/packages/api/src/hooks/use-auth.ts
+++ b/packages/api/src/hooks/use-auth.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import type { LoginRequest, RegisterRequest, LogoutRequest } from "@shinhanqna/types";
+import { login, register, logout } from "../endpoints/auth";
+
+export function useLogin() {
+  return useMutation({
+    mutationFn: (data: LoginRequest) => login(data),
+  });
+}
+
+export function useRegister() {
+  return useMutation({
+    mutationFn: (data: RegisterRequest) => register(data),
+  });
+}
+
+export function useLogout() {
+  return useMutation({
+    mutationFn: (data: LogoutRequest) => logout(data),
+  });
+}

--- a/packages/api/src/hooks/use-comments.ts
+++ b/packages/api/src/hooks/use-comments.ts
@@ -3,6 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { CommentCreateRequest, CommentUpdateRequest } from "@shinhanqna/types";
 import { commentKeys, fetchComments, createComment, updateComment, deleteComment } from "../endpoints/comments";
+import { postKeys } from "../endpoints/posts";
 
 export function useComments(postId: number) {
   return useQuery({
@@ -17,6 +18,8 @@ export function useCreateComment(postId: number) {
     mutationFn: (data: CommentCreateRequest) => createComment(postId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: commentKeys.list(postId) });
+      queryClient.invalidateQueries({ queryKey: postKeys.detail(postId) });
+      queryClient.invalidateQueries({ queryKey: postKeys.lists() });
     },
   });
 }
@@ -38,6 +41,8 @@ export function useDeleteComment(postId: number) {
     mutationFn: (commentId: number) => deleteComment(postId, commentId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: commentKeys.list(postId) });
+      queryClient.invalidateQueries({ queryKey: postKeys.detail(postId) });
+      queryClient.invalidateQueries({ queryKey: postKeys.lists() });
     },
   });
 }

--- a/packages/api/src/hooks/use-comments.ts
+++ b/packages/api/src/hooks/use-comments.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { CommentCreateRequest, CommentUpdateRequest } from "@shinhanqna/types";
+import { commentKeys, fetchComments, createComment, updateComment, deleteComment } from "../endpoints/comments";
+
+export function useComments(postId: number) {
+  return useQuery({
+    queryKey: commentKeys.list(postId),
+    queryFn: () => fetchComments(postId),
+  });
+}
+
+export function useCreateComment(postId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CommentCreateRequest) => createComment(postId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: commentKeys.list(postId) });
+    },
+  });
+}
+
+export function useUpdateComment(postId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ commentId, data }: { commentId: number; data: CommentUpdateRequest }) =>
+      updateComment(postId, commentId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: commentKeys.list(postId) });
+    },
+  });
+}
+
+export function useDeleteComment(postId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (commentId: number) => deleteComment(postId, commentId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: commentKeys.list(postId) });
+    },
+  });
+}

--- a/packages/api/src/hooks/use-like.ts
+++ b/packages/api/src/hooks/use-like.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { postKeys } from "../endpoints/posts";
+import { toggleLike } from "../endpoints/likes";
+
+export function useToggleLike(postId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => toggleLike(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: postKeys.detail(postId) });
+    },
+  });
+}

--- a/packages/api/src/hooks/use-like.ts
+++ b/packages/api/src/hooks/use-like.ts
@@ -10,6 +10,7 @@ export function useToggleLike(postId: number) {
     mutationFn: () => toggleLike(postId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: postKeys.detail(postId) });
+      queryClient.invalidateQueries({ queryKey: postKeys.lists() });
     },
   });
 }

--- a/packages/api/src/hooks/use-member.ts
+++ b/packages/api/src/hooks/use-member.ts
@@ -1,0 +1,11 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import type { NicknameUpdateRequest } from "@shinhanqna/types";
+import { updateNickname } from "../endpoints/members";
+
+export function useUpdateNickname() {
+  return useMutation({
+    mutationFn: (data: NicknameUpdateRequest) => updateNickname(data),
+  });
+}

--- a/packages/api/src/hooks/use-posts.ts
+++ b/packages/api/src/hooks/use-posts.ts
@@ -15,6 +15,7 @@ export function usePost(postId: number) {
   return useQuery({
     queryKey: postKeys.detail(postId),
     queryFn: () => fetchPost(postId),
+    enabled: postId > 0,
   });
 }
 
@@ -44,8 +45,9 @@ export function useDeletePost() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (postId: number) => deletePost(postId),
-    onSuccess: () => {
+    onSuccess: (_, postId) => {
       queryClient.invalidateQueries({ queryKey: postKeys.lists() });
+      queryClient.removeQueries({ queryKey: postKeys.detail(postId) });
     },
   });
 }

--- a/packages/api/src/hooks/use-posts.ts
+++ b/packages/api/src/hooks/use-posts.ts
@@ -6,7 +6,7 @@ import { postKeys, fetchPosts, fetchPost, createPost, updatePost, deletePost } f
 
 export function usePosts(boardType?: BoardType, page = 0, size = 20) {
   return useQuery({
-    queryKey: postKeys.list(boardType, page),
+    queryKey: postKeys.list(boardType, page, size),
     queryFn: () => fetchPosts({ boardType, page, size }),
   });
 }

--- a/packages/api/src/hooks/use-posts.ts
+++ b/packages/api/src/hooks/use-posts.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { BoardType, PostCreateRequest, PostUpdateRequest } from "@shinhanqna/types";
+import { postKeys, fetchPosts, fetchPost, createPost, updatePost, deletePost } from "../endpoints/posts";
+
+export function usePosts(boardType?: BoardType, page = 0, size = 20) {
+  return useQuery({
+    queryKey: postKeys.list(boardType, page),
+    queryFn: () => fetchPosts({ boardType, page, size }),
+  });
+}
+
+export function usePost(postId: number) {
+  return useQuery({
+    queryKey: postKeys.detail(postId),
+    queryFn: () => fetchPost(postId),
+  });
+}
+
+export function useCreatePost() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ data, images }: { data: PostCreateRequest; images?: File[] }) =>
+      createPost(data, images),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: postKeys.lists() });
+    },
+  });
+}
+
+export function useUpdatePost(postId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: PostUpdateRequest) => updatePost(postId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: postKeys.detail(postId) });
+      queryClient.invalidateQueries({ queryKey: postKeys.lists() });
+    },
+  });
+}
+
+export function useDeletePost() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (postId: number) => deletePost(postId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: postKeys.lists() });
+    },
+  });
+}

--- a/packages/api/src/hooks/use-report.ts
+++ b/packages/api/src/hooks/use-report.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import type { ReportCreateRequest } from "@shinhanqna/types";
+import { reportPost, reportComment } from "../endpoints/reports";
+
+export function useReportPost(postId: number) {
+  return useMutation({
+    mutationFn: (data: ReportCreateRequest) => reportPost(postId, data),
+  });
+}
+
+export function useReportComment(commentId: number) {
+  return useMutation({
+    mutationFn: (data: ReportCreateRequest) => reportComment(commentId, data),
+  });
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,1 +1,18 @@
-export {};
+export { apiFetch, ApiError } from "./client";
+export { createQueryClient } from "./query-client";
+
+export { login, register, refresh, logout } from "./endpoints/auth";
+export { postKeys, fetchPosts, fetchPost, createPost, updatePost, deletePost } from "./endpoints/posts";
+export { commentKeys, fetchComments, createComment, updateComment, deleteComment } from "./endpoints/comments";
+export { toggleLike } from "./endpoints/likes";
+export { reportPost, reportComment } from "./endpoints/reports";
+export { updateNickname } from "./endpoints/members";
+export { adminKeys, fetchPostReports, fetchCommentReports, adminDeletePost, adminDeleteComment } from "./endpoints/admin";
+
+export { usePosts, usePost, useCreatePost, useUpdatePost, useDeletePost } from "./hooks/use-posts";
+export { useComments, useCreateComment, useUpdateComment, useDeleteComment } from "./hooks/use-comments";
+export { useToggleLike } from "./hooks/use-like";
+export { useReportPost, useReportComment } from "./hooks/use-report";
+export { useLogin, useRegister, useLogout } from "./hooks/use-auth";
+export { useUpdateNickname } from "./hooks/use-member";
+export { usePostReports, useCommentReports, useAdminDeletePost, useAdminDeleteComment } from "./hooks/use-admin";

--- a/packages/api/src/query-client.ts
+++ b/packages/api/src/query-client.ts
@@ -1,0 +1,13 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+        retry: 1,
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+}

--- a/packages/types/src/admin.ts
+++ b/packages/types/src/admin.ts
@@ -1,0 +1,22 @@
+import type { ReportReason } from "./report";
+
+export interface AdminPostReportItem {
+  reportId: number;
+  postId: number;
+  reporterId: number;
+  reason: ReportReason;
+  description: string;
+  postDeleted: boolean;
+  reportedAt: string;
+}
+
+export interface AdminCommentReportItem {
+  reportId: number;
+  commentId: number;
+  postId: number;
+  reporterId: number;
+  reason: ReportReason;
+  description: string;
+  commentDeleted: boolean;
+  reportedAt: string;
+}

--- a/packages/types/src/admin.ts
+++ b/packages/types/src/admin.ts
@@ -5,7 +5,7 @@ export interface AdminPostReportItem {
   postId: number;
   reporterId: number;
   reason: ReportReason;
-  description: string;
+  description?: string;
   postDeleted: boolean;
   reportedAt: string;
 }
@@ -16,7 +16,7 @@ export interface AdminCommentReportItem {
   postId: number;
   reporterId: number;
   reason: ReportReason;
-  description: string;
+  description?: string;
   commentDeleted: boolean;
   reportedAt: string;
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1,0 +1,15 @@
+export interface ApiResponse<T> {
+  resultCode: string;
+  msg: string;
+  data: T;
+}
+
+export interface PaginatedData<T> {
+  items: T[];
+  page: number;
+  size: number;
+  totalPages: number;
+  totalElements: number;
+  hasNext: boolean;
+  hasPrevious: boolean;
+}

--- a/packages/types/src/auth.ts
+++ b/packages/types/src/auth.ts
@@ -1,0 +1,28 @@
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface RegisterRequest {
+  email: string;
+  studentNumber: string;
+  password: string;
+  nickname: string;
+}
+
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface RefreshTokenRequest {
+  refreshToken: string;
+}
+
+export interface LogoutRequest {
+  refreshToken: string;
+}
+
+export interface NicknameUpdateRequest {
+  nickname: string;
+}

--- a/packages/types/src/comment.ts
+++ b/packages/types/src/comment.ts
@@ -1,0 +1,26 @@
+export interface CommentItem {
+  commentId: number;
+  content: string;
+  anonymousLabel: string;
+  isPostAuthor: boolean;
+  deleted: boolean;
+  createdAt: string;
+  modifiedAt: string;
+}
+
+export interface CommentListResponse {
+  items: CommentItem[];
+}
+
+export interface CommentCreateRequest {
+  content: string;
+  parentId?: number;
+}
+
+export interface CommentUpdateRequest {
+  content: string;
+}
+
+export interface CommentCreateResponse {
+  commentId: number;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,1 +1,7 @@
-export {};
+export type { ApiResponse, PaginatedData } from "./api";
+export type { BoardType, RecruitStatus, RecruitmentDetail, PostDetail, PostCreateRequest, RecruitmentCreateRequest, PostUpdateRequest } from "./post";
+export type { CommentItem, CommentListResponse, CommentCreateRequest, CommentUpdateRequest, CommentCreateResponse } from "./comment";
+export type { LoginRequest, RegisterRequest, TokenPair, RefreshTokenRequest, LogoutRequest, NicknameUpdateRequest } from "./auth";
+export type { ReportReason, ReportCreateRequest, ReportCreateResponse } from "./report";
+export type { LikeToggleResponse } from "./like";
+export type { AdminPostReportItem, AdminCommentReportItem } from "./admin";

--- a/packages/types/src/like.ts
+++ b/packages/types/src/like.ts
@@ -1,0 +1,4 @@
+export interface LikeToggleResponse {
+  liked: boolean;
+  likeCount: number;
+}

--- a/packages/types/src/post.ts
+++ b/packages/types/src/post.ts
@@ -1,0 +1,43 @@
+export type BoardType = "FREE" | "QNA" | "PROJECT_RECRUIT" | "STUDY_RECRUIT";
+
+export type RecruitStatus = "OPEN" | "CLOSED";
+
+export interface RecruitmentDetail {
+  capacity: number;
+  currentCount: number;
+  contactMethod: string;
+  recruitStatus: RecruitStatus;
+  deadline: string;
+}
+
+export interface PostDetail {
+  postId: number;
+  boardType: BoardType;
+  title: string;
+  content: string;
+  likeCount: number;
+  commentCount: number;
+  imageUrls: string[];
+  recruitment: RecruitmentDetail | null;
+  authorName: string;
+  createdAt: string;
+  modifiedAt: string;
+}
+
+export interface PostCreateRequest {
+  boardType: BoardType;
+  title: string;
+  content: string;
+  recruitment?: RecruitmentCreateRequest;
+}
+
+export interface RecruitmentCreateRequest {
+  capacity: number;
+  contactMethod: string;
+  deadline: string;
+}
+
+export interface PostUpdateRequest {
+  title: string;
+  content: string;
+}

--- a/packages/types/src/report.ts
+++ b/packages/types/src/report.ts
@@ -1,0 +1,10 @@
+export type ReportReason = "SPAM" | "ABUSE" | "ADVERTISEMENT" | "ETC";
+
+export interface ReportCreateRequest {
+  reason: ReportReason;
+  description?: string;
+}
+
+export interface ReportCreateResponse {
+  reportId: number;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export { cn } from "./lib/cn";


### PR DESCRIPTION
## 연관 Issue
- closes #2

## 요약
API 명세 기반 공유 TypeScript 타입, fetch 클라이언트, React Query hooks를 구현하고 UI 패키지 export를 정리합니다.

## 변경 사항
- packages/types: 전체 API 타입 정의 (api, post, comment, auth, report, like, admin)
- packages/api: fetch wrapper (204 처리, 응답 형식 가드 포함)
- packages/api: 7개 endpoint 모듈 (auth, posts, comments, likes, reports, members, admin)
- packages/api: 8개 React Query hooks (use-posts, use-comments, use-like, use-report, use-auth, use-member, use-admin)
- packages/api: QueryClient factory
- packages/ui: barrel export에 cn 유틸리티 추가
- 리뷰 반영: 캐시 invalidation 수정, query key에 size 포함, admin description nullable, 이미지 5장 제한 검증, usePost enabled 가드

## 범위
### 포함:
- 공유 타입 전체 정의
- API 클라이언트 및 엔드포인트 함수
- React Query hooks 및 캐시 전략
- barrel export 정리

### 제외:
- UI 컴포넌트 구현
- 인증 로직 및 Route Handlers
- 페이지 단위 조립