### PR TITLE
[Feat/#4] 인증 시스템 구현

### DIFF
--- a/apps/admin/app/(auth)/layout.tsx
+++ b/apps/admin/app/(auth)/layout.tsx
@@ -1,0 +1,15 @@
+import { Logo } from "@shinhanqna/ui";
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        <div className="flex flex-col items-center mb-8">
+          <Logo size={48} className="text-cyan-500 mb-3" />
+          <h1 className="text-2xl font-bold text-gray-900">신한Q&A 관리자</h1>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/(auth)/login/page.tsx
+++ b/apps/admin/app/(auth)/login/page.tsx
@@ -8,14 +8,15 @@ import { useLogin } from "@shinhanqna/api";
 export default function AdminLoginPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const from = searchParams.get("from") || "/";
+  const rawFrom = searchParams.get("from") || "/";
+  const from = rawFrom.startsWith("/") && !rawFrom.startsWith("//") ? rawFrom : "/";
   const loginMutation = useLogin();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
 

--- a/apps/admin/app/(auth)/login/page.tsx
+++ b/apps/admin/app/(auth)/login/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Input, Button } from "@shinhanqna/ui";
+import { useLogin } from "@shinhanqna/api";
+
+export default function AdminLoginPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const from = searchParams.get("from") || "/";
+  const loginMutation = useLogin();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    loginMutation.mutate(
+      { email, password },
+      {
+        onSuccess: () => router.push(from),
+        onError: (err) => setError(err.message || "로그인에 실패했습니다."),
+      },
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <Input
+        label="이메일"
+        type="email"
+        placeholder="관리자 이메일을 입력하세요"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <Input
+        label="비밀번호"
+        type="password"
+        placeholder="비밀번호를 입력하세요"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      {error && <p className="text-sm text-red-500">{error}</p>}
+      <Button type="submit" loading={loginMutation.isPending} className="w-full mt-2">
+        로그인
+      </Button>
+    </form>
+  );
+}

--- a/apps/admin/app/api/auth/login/route.ts
+++ b/apps/admin/app/api/auth/login/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { setAuthCookies } from "@/lib/auth-cookies";
+
+const API_URL = process.env.API_URL;
+
+export async function POST(request: Request) {
+  const body = await request.json();
+
+  const res = await fetch(`${API_URL}/api/v1/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    return NextResponse.json(data, { status: res.status });
+  }
+
+  await setAuthCookies(data.data.accessToken, data.data.refreshToken);
+  return NextResponse.json({ resultCode: data.resultCode, msg: data.msg, data: {} });
+}

--- a/apps/admin/app/api/auth/login/route.ts
+++ b/apps/admin/app/api/auth/login/route.ts
@@ -4,20 +4,24 @@ import { setAuthCookies } from "@/lib/auth-cookies";
 const API_URL = process.env.API_URL;
 
 export async function POST(request: Request) {
-  const body = await request.json();
+  try {
+    const body = await request.json();
 
-  const res = await fetch(`${API_URL}/api/v1/auth/login`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+    const res = await fetch(`${API_URL}/api/v1/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
 
-  const data = await res.json();
+    const data = await res.json();
 
-  if (!res.ok) {
-    return NextResponse.json(data, { status: res.status });
+    if (!res.ok) {
+      return NextResponse.json(data, { status: res.status });
+    }
+
+    await setAuthCookies(data.data.accessToken, data.data.refreshToken);
+    return NextResponse.json({ resultCode: data.resultCode, msg: data.msg, data: {} });
+  } catch {
+    return NextResponse.json({ resultCode: "502", msg: "서버 연결 실패", data: {} }, { status: 502 });
   }
-
-  await setAuthCookies(data.data.accessToken, data.data.refreshToken);
-  return NextResponse.json({ resultCode: data.resultCode, msg: data.msg, data: {} });
 }

--- a/apps/admin/app/api/auth/logout/route.ts
+++ b/apps/admin/app/api/auth/logout/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { getRefreshToken, clearAuthCookies } from "@/lib/auth-cookies";
+
+const API_URL = process.env.API_URL;
+
+export async function POST() {
+  const refreshToken = await getRefreshToken();
+
+  if (refreshToken) {
+    await fetch(`${API_URL}/api/v1/auth/logout`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+    }).catch(() => {});
+  }
+
+  await clearAuthCookies();
+  return NextResponse.json({ resultCode: "200", msg: "로그아웃 성공", data: {} });
+}

--- a/apps/admin/app/api/auth/refresh/route.ts
+++ b/apps/admin/app/api/auth/refresh/route.ts
@@ -14,19 +14,23 @@ export async function POST() {
     );
   }
 
-  const res = await fetch(`${API_URL}/api/v1/auth/refresh`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ refreshToken }),
-  });
+  try {
+    const res = await fetch(`${API_URL}/api/v1/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+    });
 
-  const data = await res.json();
+    const data = await res.json();
 
-  if (!res.ok) {
-    await clearAuthCookies();
-    return NextResponse.json(data, { status: res.status });
+    if (!res.ok) {
+      await clearAuthCookies();
+      return NextResponse.json(data, { status: res.status });
+    }
+
+    await setAuthCookies(data.data.accessToken, data.data.refreshToken);
+    return NextResponse.json({ resultCode: data.resultCode, msg: data.msg, data: {} });
+  } catch {
+    return NextResponse.json({ resultCode: "502", msg: "서버 연결 실패", data: {} }, { status: 502 });
   }
-
-  await setAuthCookies(data.data.accessToken, data.data.refreshToken);
-  return NextResponse.json({ resultCode: data.resultCode, msg: data.msg, data: {} });
 }

--- a/apps/admin/app/api/auth/refresh/route.ts
+++ b/apps/admin/app/api/auth/refresh/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { getRefreshToken, setAuthCookies, clearAuthCookies } from "@/lib/auth-cookies";
+
+const API_URL = process.env.API_URL;
+
+export async function POST() {
+  const refreshToken = await getRefreshToken();
+
+  if (!refreshToken) {
+    await clearAuthCookies();
+    return NextResponse.json(
+      { resultCode: "401", msg: "리프레시 토큰 없음", data: {} },
+      { status: 401 },
+    );
+  }
+
+  const res = await fetch(`${API_URL}/api/v1/auth/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refreshToken }),
+  });
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    await clearAuthCookies();
+    return NextResponse.json(data, { status: res.status });
+  }
+
+  await setAuthCookies(data.data.accessToken, data.data.refreshToken);
+  return NextResponse.json({ resultCode: data.resultCode, msg: data.msg, data: {} });
+}

--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Providers } from "./providers";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -13,8 +14,8 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body className="font-sans antialiased bg-gray-50 text-gray-900">
-        {children}
+      <body className="font-sans antialiased bg-gray-100 text-gray-900">
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/apps/admin/app/lib/auth-cookies.ts
+++ b/apps/admin/app/lib/auth-cookies.ts
@@ -1,0 +1,39 @@
+import { cookies } from "next/headers";
+
+const ACCESS_TOKEN_KEY = "access_token";
+const REFRESH_TOKEN_KEY = "refresh_token";
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax" as const,
+  path: "/",
+};
+
+export async function setAuthCookies(accessToken: string, refreshToken: string) {
+  const cookieStore = await cookies();
+  cookieStore.set(ACCESS_TOKEN_KEY, accessToken, {
+    ...COOKIE_OPTIONS,
+    maxAge: 60 * 30,
+  });
+  cookieStore.set(REFRESH_TOKEN_KEY, refreshToken, {
+    ...COOKIE_OPTIONS,
+    maxAge: 60 * 60 * 24 * 7,
+  });
+}
+
+export async function getAccessToken() {
+  const cookieStore = await cookies();
+  return cookieStore.get(ACCESS_TOKEN_KEY)?.value;
+}
+
+export async function getRefreshToken() {
+  const cookieStore = await cookies();
+  return cookieStore.get(REFRESH_TOKEN_KEY)?.value;
+}
+
+export async function clearAuthCookies() {
+  const cookieStore = await cookies();
+  cookieStore.delete(ACCESS_TOKEN_KEY);
+  cookieStore.delete(REFRESH_TOKEN_KEY);
+}

--- a/apps/admin/app/providers.tsx
+++ b/apps/admin/app/providers.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useState } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { createQueryClient } from "@shinhanqna/api";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => createQueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+}

--- a/apps/admin/proxy.ts
+++ b/apps/admin/proxy.ts
@@ -7,7 +7,7 @@ export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const accessToken = request.cookies.get("access_token")?.value;
 
-  const isPublicPath = PUBLIC_PATHS.some((path) => pathname.startsWith(path));
+  const isPublicPath = PUBLIC_PATHS.some((path) => pathname === path || pathname.startsWith(path + "/"));
 
   if (!accessToken && !isPublicPath) {
     const loginUrl = new URL("/login", request.url);

--- a/apps/admin/proxy.ts
+++ b/apps/admin/proxy.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const PUBLIC_PATHS = ["/login"];
+
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const accessToken = request.cookies.get("access_token")?.value;
+
+  const isPublicPath = PUBLIC_PATHS.some((path) => pathname.startsWith(path));
+
+  if (!accessToken && !isPublicPath) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("from", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  if (accessToken && isPublicPath) {
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+};

--- a/apps/home/app/(auth)/layout.tsx
+++ b/apps/home/app/(auth)/layout.tsx
@@ -1,0 +1,15 @@
+import { Logo } from "@shinhanqna/ui";
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        <div className="flex flex-col items-center mb-8">
+          <Logo size={48} className="text-cyan-500 mb-3" />
+          <h1 className="text-2xl font-bold text-gray-900">신한Q&A</h1>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/home/app/(auth)/login/page.tsx
+++ b/apps/home/app/(auth)/login/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { Input, Button } from "@shinhanqna/ui";
+import { useLogin } from "@shinhanqna/api";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const from = searchParams.get("from") || "/";
+  const loginMutation = useLogin();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    loginMutation.mutate(
+      { email, password },
+      {
+        onSuccess: () => router.push(from),
+        onError: (err) => setError(err.message || "로그인에 실패했습니다."),
+      },
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <Input
+        label="이메일"
+        type="email"
+        placeholder="이메일을 입력하세요"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <Input
+        label="비밀번호"
+        type="password"
+        placeholder="비밀번호를 입력하세요"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      {error && <p className="text-sm text-red-500">{error}</p>}
+      <Button type="submit" loading={loginMutation.isPending} className="w-full mt-2">
+        로그인
+      </Button>
+      <p className="text-center text-sm text-gray-500">
+        계정이 없으신가요?{" "}
+        <Link href="/register" className="text-cyan-500 font-medium hover:underline">
+          회원가입
+        </Link>
+      </p>
+    </form>
+  );
+}

--- a/apps/home/app/(auth)/login/page.tsx
+++ b/apps/home/app/(auth)/login/page.tsx
@@ -9,14 +9,15 @@ import { useLogin } from "@shinhanqna/api";
 export default function LoginPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const from = searchParams.get("from") || "/";
+  const rawFrom = searchParams.get("from") || "/";
+  const from = rawFrom.startsWith("/") && !rawFrom.startsWith("//") ? rawFrom : "/";
   const loginMutation = useLogin();
 
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
 

--- a/apps/home/app/(auth)/register/page.tsx
+++ b/apps/home/app/(auth)/register/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Input, Button } from "@shinhanqna/ui";
+import { useRegister } from "@shinhanqna/api";
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const registerMutation = useRegister();
+
+  const [form, setForm] = useState({
+    email: "",
+    studentNumber: "",
+    password: "",
+    nickname: "",
+  });
+  const [error, setError] = useState("");
+
+  const update = (key: string) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setForm((prev) => ({ ...prev, [key]: e.target.value }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    registerMutation.mutate(form, {
+      onSuccess: () => router.push("/login"),
+      onError: (err) => setError(err.message || "회원가입에 실패했습니다."),
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <Input
+        label="이메일"
+        type="email"
+        placeholder="이메일을 입력하세요"
+        value={form.email}
+        onChange={update("email")}
+        required
+      />
+      <Input
+        label="학번"
+        placeholder="학번을 입력하세요"
+        value={form.studentNumber}
+        onChange={update("studentNumber")}
+        required
+      />
+      <Input
+        label="닉네임"
+        placeholder="닉네임을 입력하세요"
+        value={form.nickname}
+        onChange={update("nickname")}
+        required
+      />
+      <Input
+        label="비밀번호"
+        type="password"
+        placeholder="8자 이상 입력하세요"
+        value={form.password}
+        onChange={update("password")}
+        minLength={8}
+        required
+      />
+      {error && <p className="text-sm text-red-500">{error}</p>}
+      <Button type="submit" loading={registerMutation.isPending} className="w-full mt-2">
+        회원가입
+      </Button>
+      <p className="text-center text-sm text-gray-500">
+        이미 계정이 있으신가요?{" "}
+        <Link href="/login" className="text-cyan-500 font-medium hover:underline">
+          로그인
+        </Link>
+      </p>
+    </form>
+  );
+}

--- a/apps/home/app/api/auth/login/route.ts
+++ b/apps/home/app/api/auth/login/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { setAuthCookies } from "@/lib/auth-cookies";
+
+const API_URL = process.env.API_URL;
+
+export async function POST(request: Request) {
+  const body = await request.json();
+
+  const res = await fetch(`${API_URL}/api/v1/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    return NextResponse.json(data, { status: res.status });
+  }
+
+  await setAuthCookies(data.data.accessToken, data.data.refreshToken);
+  return NextResponse.json({ resultCode: data.resultCode, msg: data.msg, data: {} });
+}

--- a/apps/home/app/api/auth/login/route.ts
+++ b/apps/home/app/api/auth/login/route.ts
@@ -4,20 +4,24 @@ import { setAuthCookies } from "@/lib/auth-cookies";
 const API_URL = process.env.API_URL;
 
 export async function POST(request: Request) {
-  const body = await request.json();
+  try {
+    const body = await request.json();
 
-  const res = await fetch(`${API_URL}/api/v1/auth/login`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+    const res = await fetch(`${API_URL}/api/v1/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
 
-  const data = await res.json();
+    const data = await res.json();
 
-  if (!res.ok) {
-    return NextResponse.json(data, { status: res.status });
+    if (!res.ok) {
+      return NextResponse.json(data, { status: res.status });
+    }
+
+    await setAuthCookies(data.data.accessToken, data.data.refreshToken);
+    return NextResponse.json({ resultCode: data.resultCode, msg: data.msg, data: {} });
+  } catch {
+    return NextResponse.json({ resultCode: "502", msg: "서버 연결 실패", data: {} }, { status: 502 });
   }
-
-  await setAuthCookies(data.data.accessToken, data.data.refreshToken);
-  return NextResponse.json({ resultCode: data.resultCode, msg: data.msg, data: {} });
 }

--- a/apps/home/app/api/auth/logout/route.ts
+++ b/apps/home/app/api/auth/logout/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { getRefreshToken, clearAuthCookies } from "@/lib/auth-cookies";
+
+const API_URL = process.env.API_URL;
+
+export async function POST() {
+  const refreshToken = await getRefreshToken();
+
+  if (refreshToken) {
+    await fetch(`${API_URL}/api/v1/auth/logout`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+    }).catch(() => {});
+  }
+
+  await clearAuthCookies();
+  return NextResponse.json({ resultCode: "200", msg: "로그아웃 성공", data: {} });
+}

--- a/apps/home/app/api/auth/refresh/route.ts
+++ b/apps/home/app/api/auth/refresh/route.ts
@@ -14,19 +14,23 @@ export async function POST() {
     );
   }
 
-  const res = await fetch(`${API_URL}/api/v1/auth/refresh`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ refreshToken }),
-  });
+  try {
+    const res = await fetch(`${API_URL}/api/v1/auth/refresh`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+    });
 
-  const data = await res.json();
+    const data = await res.json();
 
-  if (!res.ok) {
-    await clearAuthCookies();
-    return NextResponse.json(data, { status: res.status });
+    if (!res.ok) {
+      await clearAuthCookies();
+      return NextResponse.json(data, { status: res.status });
+    }
+
+    await setAuthCookies(data.data.accessToken, data.data.refreshToken);
+    return NextResponse.json({ resultCode: data.resultCode, msg: data.msg, data: {} });
+  } catch {
+    return NextResponse.json({ resultCode: "502", msg: "서버 연결 실패", data: {} }, { status: 502 });
   }
-
-  await setAuthCookies(data.data.accessToken, data.data.refreshToken);
-  return NextResponse.json({ resultCode: data.resultCode, msg: data.msg, data: {} });
 }

--- a/apps/home/app/api/auth/refresh/route.ts
+++ b/apps/home/app/api/auth/refresh/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { getRefreshToken, setAuthCookies, clearAuthCookies } from "@/lib/auth-cookies";
+
+const API_URL = process.env.API_URL;
+
+export async function POST() {
+  const refreshToken = await getRefreshToken();
+
+  if (!refreshToken) {
+    await clearAuthCookies();
+    return NextResponse.json(
+      { resultCode: "401", msg: "리프레시 토큰 없음", data: {} },
+      { status: 401 },
+    );
+  }
+
+  const res = await fetch(`${API_URL}/api/v1/auth/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refreshToken }),
+  });
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    await clearAuthCookies();
+    return NextResponse.json(data, { status: res.status });
+  }
+
+  await setAuthCookies(data.data.accessToken, data.data.refreshToken);
+  return NextResponse.json({ resultCode: data.resultCode, msg: data.msg, data: {} });
+}

--- a/apps/home/app/api/auth/register/route.ts
+++ b/apps/home/app/api/auth/register/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+const API_URL = process.env.API_URL;
+
+export async function POST(request: Request) {
+  const body = await request.json();
+
+  const res = await fetch(`${API_URL}/api/v1/members`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/home/app/api/auth/register/route.ts
+++ b/apps/home/app/api/auth/register/route.ts
@@ -3,14 +3,18 @@ import { NextResponse } from "next/server";
 const API_URL = process.env.API_URL;
 
 export async function POST(request: Request) {
-  const body = await request.json();
+  try {
+    const body = await request.json();
 
-  const res = await fetch(`${API_URL}/api/v1/members`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+    const res = await fetch(`${API_URL}/api/v1/members`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
 
-  const data = await res.json();
-  return NextResponse.json(data, { status: res.status });
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ resultCode: "502", msg: "서버 연결 실패", data: {} }, { status: 502 });
+  }
 }

--- a/apps/home/app/layout.tsx
+++ b/apps/home/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Providers } from "./providers";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -13,8 +14,8 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body className="font-sans antialiased bg-gray-50 text-gray-900">
-        {children}
+      <body className="font-sans antialiased bg-gray-100 text-gray-900">
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/apps/home/app/lib/auth-cookies.ts
+++ b/apps/home/app/lib/auth-cookies.ts
@@ -1,0 +1,39 @@
+import { cookies } from "next/headers";
+
+const ACCESS_TOKEN_KEY = "access_token";
+const REFRESH_TOKEN_KEY = "refresh_token";
+
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax" as const,
+  path: "/",
+};
+
+export async function setAuthCookies(accessToken: string, refreshToken: string) {
+  const cookieStore = await cookies();
+  cookieStore.set(ACCESS_TOKEN_KEY, accessToken, {
+    ...COOKIE_OPTIONS,
+    maxAge: 60 * 30,
+  });
+  cookieStore.set(REFRESH_TOKEN_KEY, refreshToken, {
+    ...COOKIE_OPTIONS,
+    maxAge: 60 * 60 * 24 * 7,
+  });
+}
+
+export async function getAccessToken() {
+  const cookieStore = await cookies();
+  return cookieStore.get(ACCESS_TOKEN_KEY)?.value;
+}
+
+export async function getRefreshToken() {
+  const cookieStore = await cookies();
+  return cookieStore.get(REFRESH_TOKEN_KEY)?.value;
+}
+
+export async function clearAuthCookies() {
+  const cookieStore = await cookies();
+  cookieStore.delete(ACCESS_TOKEN_KEY);
+  cookieStore.delete(REFRESH_TOKEN_KEY);
+}

--- a/apps/home/app/providers.tsx
+++ b/apps/home/app/providers.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useState } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { createQueryClient } from "@shinhanqna/api";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => createQueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+}

--- a/apps/home/proxy.ts
+++ b/apps/home/proxy.ts
@@ -7,7 +7,7 @@ export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const accessToken = request.cookies.get("access_token")?.value;
 
-  const isPublicPath = PUBLIC_PATHS.some((path) => pathname.startsWith(path));
+  const isPublicPath = PUBLIC_PATHS.some((path) => pathname === path || pathname.startsWith(path + "/"));
 
   if (!accessToken && !isPublicPath) {
     const loginUrl = new URL("/login", request.url);

--- a/apps/home/proxy.ts
+++ b/apps/home/proxy.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const PUBLIC_PATHS = ["/login", "/register"];
+
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const accessToken = request.cookies.get("access_token")?.value;
+
+  const isPublicPath = PUBLIC_PATHS.some((path) => pathname.startsWith(path));
+
+  if (!accessToken && !isPublicPath) {
+    const loginUrl = new URL("/login", request.url);
+    loginUrl.searchParams.set("from", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  if (accessToken && isPublicPath) {
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
## 연관 Issue
- closes #4

## 요약
BFF 패턴 기반 인증 시스템을 구현합니다. httpOnly 쿠키로 토큰을 관리하고 Next.js 16 proxy.ts로 라우트를 보호합니다.

## 변경 사항
- 인증 쿠키 헬퍼 유틸리티 (both apps)
- Route Handlers: login, register, logout, refresh (home 4개, admin 3개)
- proxy.ts 라우트 보호 (both apps)
- Providers (QueryClientProvider)
- (auth) 레이아웃 + 로그인/회원가입 페이지
- 리뷰 반영: Open Redirect 방어, Route Handler try/catch, proxy 경로 매칭 정확도 개선

## 범위
### 포함:
- BFF 인증 전체 흐름 (login → cookie → proxy → logout)
- 양쪽 앱 인증 UI

### 제외:
- 메인 기능 페이지
- 클라이언트 측 401 자동 refresh (Phase 5에서 처리)