### PR TITLE
[Feat/#5] 홈 앱 핵심 기능 구현

### DIFF
--- a/apps/home/app/(main)/board/[boardType]/page.tsx
+++ b/apps/home/app/(main)/board/[boardType]/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import type { BoardType } from "@shinhanqna/types";
+import { usePosts } from "@shinhanqna/api";
+import { PostCard, Pagination, EmptyState, Spinner } from "@shinhanqna/ui";
+
+const slugToBoard: Record<string, BoardType> = {
+  free: "FREE",
+  qna: "QNA",
+  "project-recruit": "PROJECT_RECRUIT",
+  "study-recruit": "STUDY_RECRUIT",
+};
+
+const boardTitles: Record<BoardType, string> = {
+  FREE: "자유게시판",
+  QNA: "Q&A",
+  PROJECT_RECRUIT: "프로젝트 모집",
+  STUDY_RECRUIT: "스터디 모집",
+};
+
+export default function BoardPage() {
+  const router = useRouter();
+  const params = useParams<{ boardType: string }>();
+  const boardType = slugToBoard[params.boardType];
+  const [page, setPage] = useState(0);
+
+  const { data, isLoading } = usePosts(boardType, page);
+
+  if (!boardType) {
+    return <EmptyState message="존재하지 않는 게시판입니다" />;
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="px-4 py-3 border-b border-gray-200">
+        <h2 className="text-lg font-bold text-gray-900">{boardTitles[boardType]}</h2>
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center py-16">
+          <Spinner size="lg" />
+        </div>
+      ) : !data || data.items.length === 0 ? (
+        <EmptyState message="게시글이 없습니다" description="첫 번째 글을 작성해보세요" />
+      ) : (
+        <>
+          {data.items.map((post) => (
+            <PostCard
+              key={post.postId}
+              title={post.title}
+              content={post.content}
+              authorName={post.authorName}
+              boardType={post.boardType}
+              likeCount={post.likeCount}
+              commentCount={post.commentCount}
+              createdAt={post.createdAt}
+              onClick={() => router.push(`/post/${post.postId}`)}
+            />
+          ))}
+          <Pagination
+            page={data.page}
+            totalPages={data.totalPages}
+            hasNext={data.hasNext}
+            hasPrevious={data.hasPrevious}
+            onPageChange={setPage}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/home/app/(main)/layout.tsx
+++ b/apps/home/app/(main)/layout.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { Home, MessageCircle, Users, BookOpen, User, Plus } from "lucide-react";
+import Link from "next/link";
+import { ThreeColumnLayout, Sidebar, Header, MobileNav, Logo, type SidebarLink, type MobileNavItem } from "@shinhanqna/ui";
+
+const sidebarLinks: SidebarLink[] = [
+  { key: "/", label: "홈", href: "/", icon: <Home className="h-5 w-5" /> },
+  { key: "/board/free", label: "자유게시판", href: "/board/free", icon: <MessageCircle className="h-5 w-5" /> },
+  { key: "/board/qna", label: "Q&A", href: "/board/qna", icon: <BookOpen className="h-5 w-5" /> },
+  { key: "/board/project-recruit", label: "프로젝트 모집", href: "/board/project-recruit", icon: <Users className="h-5 w-5" /> },
+  { key: "/board/study-recruit", label: "스터디 모집", href: "/board/study-recruit", icon: <Users className="h-5 w-5" /> },
+  { key: "/profile", label: "프로필", href: "/profile", icon: <User className="h-5 w-5" /> },
+];
+
+const mobileNavItems: MobileNavItem[] = [
+  { key: "/", label: "홈", href: "/", icon: <Home className="h-5 w-5" /> },
+  { key: "/board/qna", label: "Q&A", href: "/board/qna", icon: <BookOpen className="h-5 w-5" /> },
+  { key: "/board/project-recruit", label: "모집", href: "/board/project-recruit", icon: <Users className="h-5 w-5" /> },
+  { key: "/profile", label: "프로필", href: "/profile", icon: <User className="h-5 w-5" /> },
+];
+
+export default function MainLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  const activeKey = sidebarLinks.find((link) =>
+    link.key === "/" ? pathname === "/" : pathname.startsWith(link.key),
+  )?.key || "/";
+
+  return (
+    <>
+      <ThreeColumnLayout
+        left={
+          <Sidebar
+            links={sidebarLinks}
+            activeKey={activeKey}
+            header={
+              <Link href="/" className="flex items-center gap-2">
+                <Logo size={28} className="text-cyan-500" />
+                <span className="text-lg font-bold text-gray-900">신한Q&A</span>
+              </Link>
+            }
+          />
+        }
+        center={
+          <div className="flex flex-col">
+            <Header
+              title="신한Q&A"
+              right={
+                <Link
+                  href="/post/new"
+                  className="flex items-center gap-1.5 rounded-full bg-cyan-500 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-600 transition-colors"
+                >
+                  <Plus className="h-4 w-4" />
+                  글쓰기
+                </Link>
+              }
+            />
+            {children}
+          </div>
+        }
+      />
+      <MobileNav items={mobileNavItems} activeKey={activeKey} />
+    </>
+  );
+}

--- a/apps/home/app/(main)/page.tsx
+++ b/apps/home/app/(main)/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { BoardType } from "@shinhanqna/types";
+import { usePosts } from "@shinhanqna/api";
+import { PostCard, BoardTabBar, Pagination, EmptyState, Spinner } from "@shinhanqna/ui";
+
+export default function HomePage() {
+  const router = useRouter();
+  const [boardType, setBoardType] = useState<BoardType | undefined>(undefined);
+  const [page, setPage] = useState(0);
+
+  const { data, isLoading } = usePosts(boardType, page);
+
+  return (
+    <div className="flex flex-col">
+      <BoardTabBar activeBoard={boardType} onChange={(bt) => { setBoardType(bt); setPage(0); }} />
+
+      {isLoading ? (
+        <div className="flex justify-center py-16">
+          <Spinner size="lg" />
+        </div>
+      ) : !data || data.items.length === 0 ? (
+        <EmptyState message="게시글이 없습니다" description="첫 번째 글을 작성해보세요" />
+      ) : (
+        <>
+          {data.items.map((post) => (
+            <PostCard
+              key={post.postId}
+              title={post.title}
+              content={post.content}
+              authorName={post.authorName}
+              boardType={post.boardType}
+              likeCount={post.likeCount}
+              commentCount={post.commentCount}
+              createdAt={post.createdAt}
+              onClick={() => router.push(`/post/${post.postId}`)}
+            />
+          ))}
+          <Pagination
+            page={data.page}
+            totalPages={data.totalPages}
+            hasNext={data.hasNext}
+            hasPrevious={data.hasPrevious}
+            onPageChange={setPage}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/home/app/(main)/post/[postId]/edit/page.tsx
+++ b/apps/home/app/(main)/post/[postId]/edit/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 import { usePost, useUpdatePost } from "@shinhanqna/api";
-import { Input, Textarea, Button, Spinner } from "@shinhanqna/ui";
+import { Input, Textarea, Button, Spinner, EmptyState } from "@shinhanqna/ui";
 
 export default function EditPostPage() {
   const router = useRouter();
@@ -17,16 +17,26 @@ export default function EditPostPage() {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const [error, setError] = useState("");
+  const initialized = useRef(false);
 
   useEffect(() => {
-    if (post) {
+    if (post && !initialized.current) {
       setTitle(post.title);
       setContent(post.content);
+      initialized.current = true;
     }
   }, [post]);
 
+  if (!Number.isInteger(postId) || postId <= 0) {
+    return <EmptyState message="잘못된 게시글 주소입니다" />;
+  }
+
   if (isLoading) {
     return <div className="flex justify-center py-16"><Spinner size="lg" /></div>;
+  }
+
+  if (!post) {
+    return <EmptyState message="게시글을 찾을 수 없습니다" />;
   }
 
   const handleSubmit = (e: React.FormEvent) => {

--- a/apps/home/app/(main)/post/[postId]/edit/page.tsx
+++ b/apps/home/app/(main)/post/[postId]/edit/page.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { usePost, useUpdatePost } from "@shinhanqna/api";
+import { Input, Textarea, Button, Spinner } from "@shinhanqna/ui";
+
+export default function EditPostPage() {
+  const router = useRouter();
+  const { postId: postIdParam } = useParams<{ postId: string }>();
+  const postId = Number(postIdParam);
+
+  const { data: post, isLoading } = usePost(postId);
+  const updateMutation = useUpdatePost(postId);
+
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (post) {
+      setTitle(post.title);
+      setContent(post.content);
+    }
+  }, [post]);
+
+  if (isLoading) {
+    return <div className="flex justify-center py-16"><Spinner size="lg" /></div>;
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    updateMutation.mutate(
+      { title, content },
+      {
+        onSuccess: () => router.push(`/post/${postId}`),
+        onError: (err) => setError(err.message || "수정에 실패했습니다."),
+      },
+    );
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200">
+        <button type="button" onClick={() => router.back()} className="text-gray-500 hover:text-gray-700">
+          <ArrowLeft className="h-5 w-5" />
+        </button>
+        <span className="text-lg font-bold text-gray-900">수정하기</span>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
+        <Input
+          label="제목"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+        />
+        <Textarea
+          label="내용"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          rows={8}
+          required
+        />
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        <Button type="submit" loading={updateMutation.isPending} className="w-full">
+          수정하기
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/home/app/(main)/post/[postId]/page.tsx
+++ b/apps/home/app/(main)/post/[postId]/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft, MoreHorizontal, Flag, Trash2, Pencil } from "lucide-react";
+import { usePost, useDeletePost, useComments, useCreateComment, useToggleLike, useReportPost } from "@shinhanqna/api";
+import { Avatar, Badge, LikeButton, CommentItem, ReportDialog, Dropdown, Spinner, EmptyState, Button, Textarea, RecruitmentBadge } from "@shinhanqna/ui";
+import type { BoardType, ReportReason } from "@shinhanqna/types";
+
+const boardLabels: Record<BoardType, string> = {
+  FREE: "자유",
+  QNA: "Q&A",
+  PROJECT_RECRUIT: "프로젝트 모집",
+  STUDY_RECRUIT: "스터디 모집",
+};
+
+export default function PostDetailPage() {
+  const router = useRouter();
+  const { postId: postIdParam } = useParams<{ postId: string }>();
+  const postId = Number(postIdParam);
+
+  const { data: post, isLoading: postLoading } = usePost(postId);
+  const { data: commentsData } = useComments(postId);
+  const deleteMutation = useDeletePost();
+  const likeMutation = useToggleLike(postId);
+  const reportMutation = useReportPost(postId);
+  const createCommentMutation = useCreateComment(postId);
+
+  const [commentText, setCommentText] = useState("");
+  const [reportOpen, setReportOpen] = useState(false);
+
+  if (postLoading) {
+    return <div className="flex justify-center py-16"><Spinner size="lg" /></div>;
+  }
+
+  if (!post) {
+    return <EmptyState message="게시글을 찾을 수 없습니다" />;
+  }
+
+  const handleDelete = () => {
+    if (confirm("정말 삭제하시겠습니까?")) {
+      deleteMutation.mutate(postId, { onSuccess: () => router.push("/") });
+    }
+  };
+
+  const handleComment = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!commentText.trim()) return;
+    createCommentMutation.mutate({ content: commentText }, { onSuccess: () => setCommentText("") });
+  };
+
+  const handleReport = (reason: ReportReason, description?: string) => {
+    reportMutation.mutate({ reason, description }, { onSuccess: () => setReportOpen(false) });
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200">
+        <button type="button" onClick={() => router.back()} className="text-gray-500 hover:text-gray-700">
+          <ArrowLeft className="h-5 w-5" />
+        </button>
+        <span className="text-lg font-bold text-gray-900">게시글</span>
+      </div>
+
+      <article className="px-4 py-4">
+        <div className="flex items-start justify-between mb-3">
+          <div className="flex items-center gap-3">
+            <Avatar fallback={post.authorName} size="lg" />
+            <div>
+              <p className="font-semibold text-gray-900">{post.authorName}</p>
+              <div className="flex items-center gap-2">
+                <Badge variant="cyan">{boardLabels[post.boardType]}</Badge>
+                <span className="text-xs text-gray-500">{new Date(post.createdAt).toLocaleDateString("ko-KR")}</span>
+              </div>
+            </div>
+          </div>
+          <Dropdown
+            trigger={<MoreHorizontal className="h-5 w-5 text-gray-500" />}
+            items={[
+              { key: "edit", label: "수정" },
+              { key: "report", label: "신고" },
+              { key: "delete", label: "삭제", danger: true },
+            ]}
+            onSelect={(key) => {
+              if (key === "edit") router.push(`/post/${postId}/edit`);
+              if (key === "report") setReportOpen(true);
+              if (key === "delete") handleDelete();
+            }}
+          />
+        </div>
+
+        <h1 className="text-xl font-bold text-gray-900 mb-2">{post.title}</h1>
+        <p className="text-base text-gray-700 whitespace-pre-wrap mb-4">{post.content}</p>
+
+        {post.imageUrls.length > 0 && (
+          <div className="flex gap-2 overflow-x-auto mb-4">
+            {post.imageUrls.map((url, i) => (
+              <img key={i} src={url} alt="" className="rounded-xl max-h-80 object-cover" />
+            ))}
+          </div>
+        )}
+
+        {post.recruitment && (
+          <div className="mb-4">
+            <RecruitmentBadge
+              capacity={post.recruitment.capacity}
+              currentCount={post.recruitment.currentCount}
+              recruitStatus={post.recruitment.recruitStatus}
+              deadline={post.recruitment.deadline}
+            />
+          </div>
+        )}
+
+        <div className="flex items-center gap-3 py-3 border-t border-gray-200">
+          <LikeButton liked={false} count={post.likeCount} onClick={() => likeMutation.mutate()} />
+        </div>
+      </article>
+
+      <div className="border-t border-gray-200">
+        <div className="px-4 py-3">
+          <h2 className="text-base font-semibold text-gray-900">댓글 {post.commentCount}</h2>
+        </div>
+
+        <form onSubmit={handleComment} className="flex gap-2 px-4 pb-3">
+          <Textarea
+            placeholder="댓글을 입력하세요"
+            value={commentText}
+            onChange={(e) => setCommentText(e.target.value)}
+            className="flex-1"
+          />
+          <Button type="submit" size="sm" loading={createCommentMutation.isPending} className="self-end">
+            작성
+          </Button>
+        </form>
+
+        {commentsData?.items.map((comment) => (
+          <CommentItem
+            key={comment.commentId}
+            content={comment.content}
+            anonymousLabel={comment.anonymousLabel}
+            isPostAuthor={comment.isPostAuthor}
+            deleted={comment.deleted}
+            createdAt={comment.createdAt}
+          />
+        ))}
+
+        {(!commentsData || commentsData.items.length === 0) && (
+          <EmptyState message="댓글이 없습니다" description="첫 번째 댓글을 남겨보세요" />
+        )}
+      </div>
+
+      <ReportDialog
+        open={reportOpen}
+        onClose={() => setReportOpen(false)}
+        onSubmit={handleReport}
+        loading={reportMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/apps/home/app/(main)/post/[postId]/page.tsx
+++ b/apps/home/app/(main)/post/[postId]/page.tsx
@@ -18,6 +18,7 @@ export default function PostDetailPage() {
   const router = useRouter();
   const { postId: postIdParam } = useParams<{ postId: string }>();
   const postId = Number(postIdParam);
+  const isValidId = Number.isInteger(postId) && postId > 0;
 
   const { data: post, isLoading: postLoading } = usePost(postId);
   const { data: commentsData } = useComments(postId);
@@ -27,7 +28,12 @@ export default function PostDetailPage() {
   const createCommentMutation = useCreateComment(postId);
 
   const [commentText, setCommentText] = useState("");
+  const [liked, setLiked] = useState(false);
   const [reportOpen, setReportOpen] = useState(false);
+
+  if (!isValidId) {
+    return <EmptyState message="잘못된 게시글 주소입니다" />;
+  }
 
   if (postLoading) {
     return <div className="flex justify-center py-16"><Spinner size="lg" /></div>;
@@ -112,7 +118,13 @@ export default function PostDetailPage() {
         )}
 
         <div className="flex items-center gap-3 py-3 border-t border-gray-200">
-          <LikeButton liked={false} count={post.likeCount} onClick={() => likeMutation.mutate()} />
+          <LikeButton
+            liked={liked}
+            count={post.likeCount}
+            onClick={() => likeMutation.mutate(undefined, {
+              onSuccess: (res) => setLiked(res.liked),
+            })}
+          />
         </div>
       </article>
 

--- a/apps/home/app/(main)/post/new/page.tsx
+++ b/apps/home/app/(main)/post/new/page.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import type { BoardType } from "@shinhanqna/types";
+import { useCreatePost } from "@shinhanqna/api";
+import { Input, Textarea, Button, Tabs, type TabItem } from "@shinhanqna/ui";
+
+const boardTabs: TabItem[] = [
+  { key: "FREE", label: "자유" },
+  { key: "QNA", label: "Q&A" },
+  { key: "PROJECT_RECRUIT", label: "프로젝트 모집" },
+  { key: "STUDY_RECRUIT", label: "스터디 모집" },
+];
+
+const isRecruitBoard = (bt: string) => bt === "PROJECT_RECRUIT" || bt === "STUDY_RECRUIT";
+
+export default function NewPostPage() {
+  const router = useRouter();
+  const createMutation = useCreatePost();
+
+  const [boardType, setBoardType] = useState<BoardType>("FREE");
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [images, setImages] = useState<File[]>([]);
+  const [capacity, setCapacity] = useState("");
+  const [contactMethod, setContactMethod] = useState("");
+  const [deadline, setDeadline] = useState("");
+  const [error, setError] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    const recruitment = isRecruitBoard(boardType) ? {
+      capacity: Number(capacity),
+      contactMethod,
+      deadline,
+    } : undefined;
+
+    createMutation.mutate(
+      { data: { boardType, title, content, recruitment }, images: images.length > 0 ? images : undefined },
+      {
+        onSuccess: () => router.push("/"),
+        onError: (err) => setError(err.message || "게시글 작성에 실패했습니다."),
+      },
+    );
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200">
+        <button type="button" onClick={() => router.back()} className="text-gray-500 hover:text-gray-700">
+          <ArrowLeft className="h-5 w-5" />
+        </button>
+        <span className="text-lg font-bold text-gray-900">글쓰기</span>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
+        <Tabs
+          items={boardTabs}
+          activeKey={boardType}
+          onChange={(key) => setBoardType(key as BoardType)}
+        />
+
+        <Input
+          label="제목"
+          placeholder="제목을 입력하세요"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+        />
+
+        <Textarea
+          label="내용"
+          placeholder="내용을 입력하세요"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          rows={8}
+          required
+        />
+
+        <div>
+          <label className="text-sm font-medium text-gray-700 mb-1.5 block">
+            이미지 (최대 5장)
+          </label>
+          <input
+            type="file"
+            accept="image/*"
+            multiple
+            onChange={(e) => setImages(Array.from(e.target.files || []).slice(0, 5))}
+            className="text-sm text-gray-500 file:mr-3 file:rounded-lg file:border-0 file:bg-gray-100 file:px-4 file:py-2 file:text-sm file:font-medium file:text-gray-700 hover:file:bg-gray-200"
+          />
+        </div>
+
+        {isRecruitBoard(boardType) && (
+          <div className="flex flex-col gap-3 p-4 rounded-xl bg-gray-100">
+            <p className="text-sm font-semibold text-gray-900">모집 정보</p>
+            <Input
+              label="모집 인원"
+              type="number"
+              min={1}
+              placeholder="1"
+              value={capacity}
+              onChange={(e) => setCapacity(e.target.value)}
+              required
+            />
+            <Input
+              label="연락 방법"
+              placeholder="오픈카톡 링크, 이메일 등"
+              value={contactMethod}
+              onChange={(e) => setContactMethod(e.target.value)}
+              required
+            />
+            <Input
+              label="마감일"
+              type="date"
+              value={deadline}
+              onChange={(e) => setDeadline(e.target.value)}
+              required
+            />
+          </div>
+        )}
+
+        {error && <p className="text-sm text-red-500">{error}</p>}
+
+        <Button type="submit" loading={createMutation.isPending} className="w-full">
+          게시하기
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/home/app/(main)/profile/page.tsx
+++ b/apps/home/app/(main)/profile/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { LogOut } from "lucide-react";
+import { useUpdateNickname, useLogout } from "@shinhanqna/api";
+import { Input, Button, Avatar } from "@shinhanqna/ui";
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const nicknameMutation = useUpdateNickname();
+  const logoutMutation = useLogout();
+
+  const [nickname, setNickname] = useState("");
+  const [success, setSuccess] = useState("");
+  const [error, setError] = useState("");
+
+  const handleNickname = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
+
+    if (!nickname.trim()) return;
+
+    nicknameMutation.mutate(
+      { nickname },
+      {
+        onSuccess: () => { setSuccess("닉네임이 변경되었습니다."); setNickname(""); },
+        onError: (err) => setError(err.message || "닉네임 변경에 실패했습니다."),
+      },
+    );
+  };
+
+  const handleLogout = () => {
+    logoutMutation.mutate(
+      { refreshToken: "" },
+      { onSuccess: () => router.push("/login") },
+    );
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className="px-4 py-3 border-b border-gray-200">
+        <h2 className="text-lg font-bold text-gray-900">프로필</h2>
+      </div>
+
+      <div className="p-4 flex flex-col gap-6">
+        <div className="flex items-center gap-4">
+          <Avatar fallback="나" size="lg" />
+          <div>
+            <p className="font-semibold text-gray-900">내 프로필</p>
+            <p className="text-sm text-gray-500">닉네임을 변경할 수 있습니다</p>
+          </div>
+        </div>
+
+        <form onSubmit={handleNickname} className="flex flex-col gap-3">
+          <Input
+            label="새 닉네임"
+            placeholder="변경할 닉네임을 입력하세요"
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            required
+          />
+          {success && <p className="text-sm text-green-500">{success}</p>}
+          {error && <p className="text-sm text-red-500">{error}</p>}
+          <Button type="submit" loading={nicknameMutation.isPending}>
+            닉네임 변경
+          </Button>
+        </form>
+
+        <div className="border-t border-gray-200 pt-4">
+          <Button
+            variant="ghost"
+            onClick={handleLogout}
+            loading={logoutMutation.isPending}
+            className="w-full text-red-500 hover:text-red-600 hover:bg-red-100"
+          >
+            <LogOut className="h-4 w-4 mr-2" />
+            로그아웃
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/home/app/api/comments/[commentId]/reports/route.ts
+++ b/apps/home/app/api/comments/[commentId]/reports/route.ts
@@ -1,0 +1,7 @@
+import { apiProxy } from "@/lib/api-proxy";
+
+export async function POST(request: Request, { params }: { params: Promise<{ commentId: string }> }) {
+  const { commentId } = await params;
+  const body = await request.json();
+  return apiProxy(`/api/v1/comments/${commentId}/reports`, { method: "POST", body, contentType: "application/json" });
+}

--- a/apps/home/app/api/members/me/nickname/route.ts
+++ b/apps/home/app/api/members/me/nickname/route.ts
@@ -1,0 +1,6 @@
+import { apiProxy } from "@/lib/api-proxy";
+
+export async function PATCH(request: Request) {
+  const body = await request.json();
+  return apiProxy("/api/v1/members/me/nickname", { method: "PATCH", body, contentType: "application/json" });
+}

--- a/apps/home/app/api/posts/[postId]/comments/[commentId]/route.ts
+++ b/apps/home/app/api/posts/[postId]/comments/[commentId]/route.ts
@@ -1,0 +1,12 @@
+import { apiProxy } from "@/lib/api-proxy";
+
+export async function PATCH(request: Request, { params }: { params: Promise<{ postId: string; commentId: string }> }) {
+  const { postId, commentId } = await params;
+  const body = await request.json();
+  return apiProxy(`/api/v1/posts/${postId}/comments/${commentId}`, { method: "PATCH", body, contentType: "application/json" });
+}
+
+export async function DELETE(_: Request, { params }: { params: Promise<{ postId: string; commentId: string }> }) {
+  const { postId, commentId } = await params;
+  return apiProxy(`/api/v1/posts/${postId}/comments/${commentId}`, { method: "DELETE" });
+}

--- a/apps/home/app/api/posts/[postId]/comments/route.ts
+++ b/apps/home/app/api/posts/[postId]/comments/route.ts
@@ -1,0 +1,12 @@
+import { apiProxy } from "@/lib/api-proxy";
+
+export async function GET(_: Request, { params }: { params: Promise<{ postId: string }> }) {
+  const { postId } = await params;
+  return apiProxy(`/api/v1/posts/${postId}/comments`);
+}
+
+export async function POST(request: Request, { params }: { params: Promise<{ postId: string }> }) {
+  const { postId } = await params;
+  const body = await request.json();
+  return apiProxy(`/api/v1/posts/${postId}/comments`, { method: "POST", body, contentType: "application/json" });
+}

--- a/apps/home/app/api/posts/[postId]/likes/route.ts
+++ b/apps/home/app/api/posts/[postId]/likes/route.ts
@@ -1,0 +1,6 @@
+import { apiProxy } from "@/lib/api-proxy";
+
+export async function POST(_: Request, { params }: { params: Promise<{ postId: string }> }) {
+  const { postId } = await params;
+  return apiProxy(`/api/v1/posts/${postId}/likes`, { method: "POST" });
+}

--- a/apps/home/app/api/posts/[postId]/reports/route.ts
+++ b/apps/home/app/api/posts/[postId]/reports/route.ts
@@ -1,0 +1,7 @@
+import { apiProxy } from "@/lib/api-proxy";
+
+export async function POST(request: Request, { params }: { params: Promise<{ postId: string }> }) {
+  const { postId } = await params;
+  const body = await request.json();
+  return apiProxy(`/api/v1/posts/${postId}/reports`, { method: "POST", body, contentType: "application/json" });
+}

--- a/apps/home/app/api/posts/[postId]/route.ts
+++ b/apps/home/app/api/posts/[postId]/route.ts
@@ -1,0 +1,17 @@
+import { apiProxy } from "@/lib/api-proxy";
+
+export async function GET(_: Request, { params }: { params: Promise<{ postId: string }> }) {
+  const { postId } = await params;
+  return apiProxy(`/api/v1/posts/${postId}`);
+}
+
+export async function PATCH(request: Request, { params }: { params: Promise<{ postId: string }> }) {
+  const { postId } = await params;
+  const body = await request.json();
+  return apiProxy(`/api/v1/posts/${postId}`, { method: "PATCH", body, contentType: "application/json" });
+}
+
+export async function DELETE(_: Request, { params }: { params: Promise<{ postId: string }> }) {
+  const { postId } = await params;
+  return apiProxy(`/api/v1/posts/${postId}`, { method: "DELETE" });
+}

--- a/apps/home/app/api/posts/route.ts
+++ b/apps/home/app/api/posts/route.ts
@@ -1,0 +1,12 @@
+import { type NextRequest } from "next/server";
+import { apiProxy, apiProxyFormData } from "@/lib/api-proxy";
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams.toString();
+  return apiProxy(`/api/v1/posts${searchParams ? `?${searchParams}` : ""}`);
+}
+
+export async function POST(request: NextRequest) {
+  const formData = await request.formData();
+  return apiProxyFormData("/api/v1/posts", formData);
+}

--- a/apps/home/app/lib/api-proxy.ts
+++ b/apps/home/app/lib/api-proxy.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { getAccessToken } from "./auth-cookies";
+
+const API_URL = process.env.API_URL;
+
+export async function apiProxy(
+  path: string,
+  options: { method?: string; body?: unknown; contentType?: string } = {},
+) {
+  const accessToken = await getAccessToken();
+  const { method = "GET", body, contentType } = options;
+
+  const headers: Record<string, string> = {};
+  if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
+  if (contentType) headers["Content-Type"] = contentType;
+
+  try {
+    const res = await fetch(`${API_URL}${path}`, {
+      method,
+      headers,
+      body: body !== undefined
+        ? typeof body === "string" ? body : JSON.stringify(body)
+        : undefined,
+    });
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ resultCode: "502", msg: "서버 연결 실패", data: {} }, { status: 502 });
+  }
+}
+
+export async function apiProxyFormData(path: string, formData: FormData) {
+  const accessToken = await getAccessToken();
+
+  const headers: Record<string, string> = {};
+  if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
+
+  try {
+    const res = await fetch(`${API_URL}${path}`, {
+      method: "POST",
+      headers,
+      body: formData,
+    });
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ resultCode: "502", msg: "서버 연결 실패", data: {} }, { status: 502 });
+  }
+}

--- a/apps/home/app/lib/api-proxy.ts
+++ b/apps/home/app/lib/api-proxy.ts
@@ -23,6 +23,10 @@ export async function apiProxy(
         : undefined,
     });
 
+    if (res.status === 204 || res.headers.get("content-length") === "0") {
+      return NextResponse.json({ resultCode: "200", msg: "success", data: {} }, { status: res.status });
+    }
+
     const data = await res.json();
     return NextResponse.json(data, { status: res.status });
   } catch {
@@ -42,6 +46,10 @@ export async function apiProxyFormData(path: string, formData: FormData) {
       headers,
       body: formData,
     });
+
+    if (res.status === 204 || res.headers.get("content-length") === "0") {
+      return NextResponse.json({ resultCode: "200", msg: "success", data: {} }, { status: res.status });
+    }
 
     const data = await res.json();
     return NextResponse.json(data, { status: res.status });

--- a/apps/home/app/page.tsx
+++ b/apps/home/app/page.tsx
@@ -1,7 +1,0 @@
-export default function HomePage() {
-  return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-3xl font-bold text-cyan-900">ShinhanQNA</h1>
-    </main>
-  );
-}

--- a/packages/api/src/hooks/use-comments.ts
+++ b/packages/api/src/hooks/use-comments.ts
@@ -9,6 +9,7 @@ export function useComments(postId: number) {
   return useQuery({
     queryKey: commentKeys.list(postId),
     queryFn: () => fetchComments(postId),
+    enabled: postId > 0,
   });
 }
 


### PR DESCRIPTION
## 연관 Issue
- closes #5

## 요약
홈 앱의 핵심 기능을 구현합니다. 3-column 레이아웃, 게시판 피드, 게시글 CRUD, 댓글, 좋아요, 신고, 프로필 기능을 포함합니다.

## 변경 사항
- BFF API 프록시 헬퍼 (api-proxy.ts) + 204 빈 응답 처리
- Route Handlers: posts CRUD, comments CRUD, likes toggle, reports, members nickname
- 메인 3-column 레이아웃 + 사이드바 네비게이션 + 모바일 하단 탭
- 홈 피드 (BoardTabBar + PostCard + Pagination)
- 게시판별 뷰 (slug → BoardType 매핑)
- 게시글 상세 (댓글, 좋아요 토글, 신고 다이얼로그, 이미지, 모집 뱃지)
- 게시글 작성 (boardType 선택, 이미지 업로드, 모집 필드 조건부 노출)
- 게시글 수정 (초기화 1회 제한, not-found 가드)
- 프로필 (닉네임 변경 + 로그아웃)
- 리뷰 반영: apiProxy 204 처리, postId NaN 가드, LikeButton 상태 관리, useComments enabled, Edit 페이지 가드

## 범위
### 포함:
- 홈 앱 전체 기능 페이지 + BFF Route Handlers

### 제외:
- 관리자 앱 (Phase 6)
- 클라이언트 401 자동 refresh