### PR TITLE
[Feat/#6] 관리자 앱 구현

### DIFF
--- a/apps/admin/app/(dashboard)/layout.tsx
+++ b/apps/admin/app/(dashboard)/layout.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import { LayoutDashboard, FileWarning, MessageSquareWarning, LogOut } from "lucide-react";
+import Link from "next/link";
+import { Sidebar, Logo, Button, type SidebarLink } from "@shinhanqna/ui";
+import { useLogout } from "@shinhanqna/api";
+
+const sidebarLinks: SidebarLink[] = [
+  { key: "/", label: "대시보드", href: "/", icon: <LayoutDashboard className="h-5 w-5" /> },
+  { key: "/reports/posts", label: "게시글 신고", href: "/reports/posts", icon: <FileWarning className="h-5 w-5" /> },
+  { key: "/reports/comments", label: "댓글 신고", href: "/reports/comments", icon: <MessageSquareWarning className="h-5 w-5" /> },
+];
+
+export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const logoutMutation = useLogout();
+
+  const activeKey = sidebarLinks.find((link) =>
+    link.key === "/" ? pathname === "/" : pathname.startsWith(link.key),
+  )?.key || "/";
+
+  const handleLogout = () => {
+    logoutMutation.mutate(
+      { refreshToken: "" },
+      { onSuccess: () => router.push("/login") },
+    );
+  };
+
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar
+        links={sidebarLinks}
+        activeKey={activeKey}
+        header={
+          <Link href="/" className="flex items-center gap-2">
+            <Logo size={28} className="text-cyan-500" />
+            <span className="text-lg font-bold text-gray-900">관리자</span>
+          </Link>
+        }
+        footer={
+          <Button variant="ghost" onClick={handleLogout} className="w-full text-gray-500 justify-start">
+            <LogOut className="h-4 w-4 mr-2" />
+            로그아웃
+          </Button>
+        }
+      />
+      <main className="flex-1 bg-gray-100">
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/apps/admin/app/(dashboard)/layout.tsx
+++ b/apps/admin/app/(dashboard)/layout.tsx
@@ -24,7 +24,10 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   const handleLogout = () => {
     logoutMutation.mutate(
       { refreshToken: "" },
-      { onSuccess: () => router.push("/login") },
+      {
+        onSuccess: () => router.push("/login"),
+        onError: () => router.push("/login"),
+      },
     );
   };
 

--- a/apps/admin/app/(dashboard)/page.tsx
+++ b/apps/admin/app/(dashboard)/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { FileWarning, MessageSquareWarning } from "lucide-react";
+import { usePostReports, useCommentReports } from "@shinhanqna/api";
+import { Spinner } from "@shinhanqna/ui";
+
+export default function DashboardPage() {
+  const { data: postReports, isLoading: postsLoading } = usePostReports(0, 1);
+  const { data: commentReports, isLoading: commentsLoading } = useCommentReports(0, 1);
+
+  const isLoading = postsLoading || commentsLoading;
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">대시보드</h1>
+
+      {isLoading ? (
+        <div className="flex justify-center py-16"><Spinner size="lg" /></div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="rounded-xl bg-white p-6 shadow-card">
+            <div className="flex items-center gap-3 mb-2">
+              <div className="rounded-lg bg-orange-100 p-2">
+                <FileWarning className="h-5 w-5 text-orange-500" />
+              </div>
+              <h2 className="text-base font-semibold text-gray-900">게시글 신고</h2>
+            </div>
+            <p className="text-3xl font-bold text-gray-900">{postReports?.totalElements ?? 0}</p>
+            <p className="text-sm text-gray-500 mt-1">전체 신고 건수</p>
+          </div>
+
+          <div className="rounded-xl bg-white p-6 shadow-card">
+            <div className="flex items-center gap-3 mb-2">
+              <div className="rounded-lg bg-red-100 p-2">
+                <MessageSquareWarning className="h-5 w-5 text-red-500" />
+              </div>
+              <h2 className="text-base font-semibold text-gray-900">댓글 신고</h2>
+            </div>
+            <p className="text-3xl font-bold text-gray-900">{commentReports?.totalElements ?? 0}</p>
+            <p className="text-sm text-gray-500 mt-1">전체 신고 건수</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin/app/(dashboard)/reports/comments/page.tsx
+++ b/apps/admin/app/(dashboard)/reports/comments/page.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import { useCommentReports, useAdminDeleteComment } from "@shinhanqna/api";
+import { Badge, Button, Pagination, Spinner, EmptyState, Modal } from "@shinhanqna/ui";
+import type { ReportReason } from "@shinhanqna/types";
+
+const reasonLabels: Record<ReportReason, string> = {
+  SPAM: "스팸",
+  ABUSE: "욕설/비방",
+  ADVERTISEMENT: "광고",
+  ETC: "기타",
+};
+
+export default function CommentReportsPage() {
+  const [page, setPage] = useState(0);
+  const { data, isLoading } = useCommentReports(page);
+  const deleteMutation = useAdminDeleteComment();
+  const [deleteTarget, setDeleteTarget] = useState<number | null>(null);
+
+  const handleDelete = () => {
+    if (deleteTarget === null) return;
+    deleteMutation.mutate(deleteTarget, {
+      onSuccess: () => setDeleteTarget(null),
+    });
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">댓글 신고 관리</h1>
+
+      {isLoading ? (
+        <div className="flex justify-center py-16"><Spinner size="lg" /></div>
+      ) : !data || data.items.length === 0 ? (
+        <EmptyState message="신고된 댓글이 없습니다" />
+      ) : (
+        <>
+          <div className="rounded-xl bg-white shadow-card overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-100 text-gray-600">
+                <tr>
+                  <th className="text-left px-4 py-3 font-medium">댓글 ID</th>
+                  <th className="text-left px-4 py-3 font-medium">게시글 ID</th>
+                  <th className="text-left px-4 py-3 font-medium">사유</th>
+                  <th className="text-left px-4 py-3 font-medium">설명</th>
+                  <th className="text-left px-4 py-3 font-medium">상태</th>
+                  <th className="text-left px-4 py-3 font-medium">신고일</th>
+                  <th className="text-right px-4 py-3 font-medium">관리</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {data.items.map((report) => (
+                  <tr key={report.reportId} className="hover:bg-gray-100 transition-colors">
+                    <td className="px-4 py-3 text-gray-900">{report.commentId}</td>
+                    <td className="px-4 py-3 text-gray-600">{report.postId}</td>
+                    <td className="px-4 py-3">
+                      <Badge variant="orange">{reasonLabels[report.reason]}</Badge>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600 max-w-[200px] truncate">{report.description || "-"}</td>
+                    <td className="px-4 py-3">
+                      {report.commentDeleted
+                        ? <Badge variant="default">삭제됨</Badge>
+                        : <Badge variant="red">미처리</Badge>
+                      }
+                    </td>
+                    <td className="px-4 py-3 text-gray-500">{new Date(report.reportedAt).toLocaleDateString("ko-KR")}</td>
+                    <td className="px-4 py-3 text-right">
+                      {!report.commentDeleted && (
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          onClick={() => setDeleteTarget(report.commentId)}
+                        >
+                          삭제
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <Pagination
+            page={data.page}
+            totalPages={data.totalPages}
+            hasNext={data.hasNext}
+            hasPrevious={data.hasPrevious}
+            onPageChange={setPage}
+          />
+        </>
+      )}
+
+      <Modal open={deleteTarget !== null} onClose={() => setDeleteTarget(null)} title="댓글 삭제">
+        <p className="text-sm text-gray-600 mb-4">이 댓글을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</p>
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={() => setDeleteTarget(null)}>취소</Button>
+          <Button variant="danger" onClick={handleDelete} loading={deleteMutation.isPending}>삭제</Button>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/apps/admin/app/(dashboard)/reports/comments/page.tsx
+++ b/apps/admin/app/(dashboard)/reports/comments/page.tsx
@@ -22,6 +22,7 @@ export default function CommentReportsPage() {
     if (deleteTarget === null) return;
     deleteMutation.mutate(deleteTarget, {
       onSuccess: () => setDeleteTarget(null),
+      onError: () => setDeleteTarget(null),
     });
   };
 

--- a/apps/admin/app/(dashboard)/reports/posts/page.tsx
+++ b/apps/admin/app/(dashboard)/reports/posts/page.tsx
@@ -22,6 +22,7 @@ export default function PostReportsPage() {
     if (deleteTarget === null) return;
     deleteMutation.mutate(deleteTarget, {
       onSuccess: () => setDeleteTarget(null),
+      onError: () => setDeleteTarget(null),
     });
   };
 

--- a/apps/admin/app/(dashboard)/reports/posts/page.tsx
+++ b/apps/admin/app/(dashboard)/reports/posts/page.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import { usePostReports, useAdminDeletePost } from "@shinhanqna/api";
+import { Badge, Button, Pagination, Spinner, EmptyState, Modal } from "@shinhanqna/ui";
+import type { ReportReason } from "@shinhanqna/types";
+
+const reasonLabels: Record<ReportReason, string> = {
+  SPAM: "스팸",
+  ABUSE: "욕설/비방",
+  ADVERTISEMENT: "광고",
+  ETC: "기타",
+};
+
+export default function PostReportsPage() {
+  const [page, setPage] = useState(0);
+  const { data, isLoading } = usePostReports(page);
+  const deleteMutation = useAdminDeletePost();
+  const [deleteTarget, setDeleteTarget] = useState<number | null>(null);
+
+  const handleDelete = () => {
+    if (deleteTarget === null) return;
+    deleteMutation.mutate(deleteTarget, {
+      onSuccess: () => setDeleteTarget(null),
+    });
+  };
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">게시글 신고 관리</h1>
+
+      {isLoading ? (
+        <div className="flex justify-center py-16"><Spinner size="lg" /></div>
+      ) : !data || data.items.length === 0 ? (
+        <EmptyState message="신고된 게시글이 없습니다" />
+      ) : (
+        <>
+          <div className="rounded-xl bg-white shadow-card overflow-hidden">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-100 text-gray-600">
+                <tr>
+                  <th className="text-left px-4 py-3 font-medium">게시글 ID</th>
+                  <th className="text-left px-4 py-3 font-medium">사유</th>
+                  <th className="text-left px-4 py-3 font-medium">설명</th>
+                  <th className="text-left px-4 py-3 font-medium">상태</th>
+                  <th className="text-left px-4 py-3 font-medium">신고일</th>
+                  <th className="text-right px-4 py-3 font-medium">관리</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {data.items.map((report) => (
+                  <tr key={report.reportId} className="hover:bg-gray-100 transition-colors">
+                    <td className="px-4 py-3 text-gray-900">{report.postId}</td>
+                    <td className="px-4 py-3">
+                      <Badge variant="orange">{reasonLabels[report.reason]}</Badge>
+                    </td>
+                    <td className="px-4 py-3 text-gray-600 max-w-[200px] truncate">{report.description || "-"}</td>
+                    <td className="px-4 py-3">
+                      {report.postDeleted
+                        ? <Badge variant="default">삭제됨</Badge>
+                        : <Badge variant="red">미처리</Badge>
+                      }
+                    </td>
+                    <td className="px-4 py-3 text-gray-500">{new Date(report.reportedAt).toLocaleDateString("ko-KR")}</td>
+                    <td className="px-4 py-3 text-right">
+                      {!report.postDeleted && (
+                        <Button
+                          variant="danger"
+                          size="sm"
+                          onClick={() => setDeleteTarget(report.postId)}
+                        >
+                          삭제
+                        </Button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <Pagination
+            page={data.page}
+            totalPages={data.totalPages}
+            hasNext={data.hasNext}
+            hasPrevious={data.hasPrevious}
+            onPageChange={setPage}
+          />
+        </>
+      )}
+
+      <Modal open={deleteTarget !== null} onClose={() => setDeleteTarget(null)} title="게시글 삭제">
+        <p className="text-sm text-gray-600 mb-4">이 게시글을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</p>
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={() => setDeleteTarget(null)}>취소</Button>
+          <Button variant="danger" onClick={handleDelete} loading={deleteMutation.isPending}>삭제</Button>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/apps/admin/app/api/admin/comments/[commentId]/route.ts
+++ b/apps/admin/app/api/admin/comments/[commentId]/route.ts
@@ -1,0 +1,6 @@
+import { apiProxy } from "@/lib/api-proxy";
+
+export async function DELETE(_: Request, { params }: { params: Promise<{ commentId: string }> }) {
+  const { commentId } = await params;
+  return apiProxy(`/api/v1/admin/comments/${commentId}`, { method: "DELETE" });
+}

--- a/apps/admin/app/api/admin/posts/[postId]/route.ts
+++ b/apps/admin/app/api/admin/posts/[postId]/route.ts
@@ -1,0 +1,6 @@
+import { apiProxy } from "@/lib/api-proxy";
+
+export async function DELETE(_: Request, { params }: { params: Promise<{ postId: string }> }) {
+  const { postId } = await params;
+  return apiProxy(`/api/v1/admin/posts/${postId}`, { method: "DELETE" });
+}

--- a/apps/admin/app/api/admin/reports/comments/route.ts
+++ b/apps/admin/app/api/admin/reports/comments/route.ts
@@ -1,0 +1,7 @@
+import { type NextRequest } from "next/server";
+import { apiProxy } from "@/lib/api-proxy";
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams.toString();
+  return apiProxy(`/api/v1/admin/reports/comments${searchParams ? `?${searchParams}` : ""}`);
+}

--- a/apps/admin/app/api/admin/reports/posts/route.ts
+++ b/apps/admin/app/api/admin/reports/posts/route.ts
@@ -1,0 +1,7 @@
+import { type NextRequest } from "next/server";
+import { apiProxy } from "@/lib/api-proxy";
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams.toString();
+  return apiProxy(`/api/v1/admin/reports/posts${searchParams ? `?${searchParams}` : ""}`);
+}

--- a/apps/admin/app/lib/api-proxy.ts
+++ b/apps/admin/app/lib/api-proxy.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { getAccessToken } from "./auth-cookies";
+
+const API_URL = process.env.API_URL;
+
+export async function apiProxy(
+  path: string,
+  options: { method?: string; body?: unknown; contentType?: string } = {},
+) {
+  const accessToken = await getAccessToken();
+  const { method = "GET", body, contentType } = options;
+
+  const headers: Record<string, string> = {};
+  if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
+  if (contentType) headers["Content-Type"] = contentType;
+
+  try {
+    const res = await fetch(`${API_URL}${path}`, {
+      method,
+      headers,
+      body: body !== undefined
+        ? typeof body === "string" ? body : JSON.stringify(body)
+        : undefined,
+    });
+
+    if (res.status === 204 || res.headers.get("content-length") === "0") {
+      return NextResponse.json({ resultCode: "200", msg: "success", data: {} }, { status: res.status });
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json({ resultCode: "502", msg: "서버 연결 실패", data: {} }, { status: 502 });
+  }
+}

--- a/apps/admin/app/page.tsx
+++ b/apps/admin/app/page.tsx
@@ -1,7 +1,0 @@
-export default function AdminPage() {
-  return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-3xl font-bold text-cyan-900">ShinhanQNA Admin</h1>
-    </main>
-  );
-}


### PR DESCRIPTION
## 연관 Issue
- closes #6

## 요약
관리자 앱의 대시보드, 신고 관리, 콘텐츠 삭제 기능을 구현합니다.

## 변경 사항
- Admin BFF API 프록시 (204 처리 포함)
- Route Handlers: 신고 목록 조회, 게시글/댓글 삭제
- 대시보드 사이드바 레이아웃 + 로그아웃
- 대시보드 요약 (신고 건수 카드)
- 게시글 신고 관리 테이블 + 삭제 확인 모달
- 댓글 신고 관리 테이블 + 삭제 확인 모달
- 리뷰 반영: 삭제 모달 onError 처리, 로그아웃 onError 리다이렉트

## 범위
### 포함:
- 관리자 앱 전체 기능

### 제외:
- 사용자 관리, 통계/분석