### PR TITLE
[Design/#7] 반응형 대응

### DIFF
--- a/apps/admin/app/(dashboard)/loading.tsx
+++ b/apps/admin/app/(dashboard)/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@shinhanqna/ui";
+
+export default function DashboardLoading() {
+  return (
+    <div className="p-6">
+      <Skeleton className="h-8 w-32 mb-6" />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <Skeleton className="h-32 rounded-xl" />
+        <Skeleton className="h-32 rounded-xl" />
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/error.tsx
+++ b/apps/admin/app/error.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@shinhanqna/ui";
+
+export default function Error({ reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="flex flex-col items-center text-center">
+        <AlertTriangle className="h-12 w-12 text-orange-500 mb-4" />
+        <h2 className="text-xl font-bold text-gray-900 mb-2">문제가 발생했습니다</h2>
+        <p className="text-sm text-gray-500 mb-6">잠시 후 다시 시도해주세요.</p>
+        <Button onClick={reset}>다시 시도</Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/not-found.tsx
+++ b/apps/admin/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { FileQuestion } from "lucide-react";
+import { Button } from "@shinhanqna/ui";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="flex flex-col items-center text-center">
+        <FileQuestion className="h-12 w-12 text-gray-300 mb-4" />
+        <h2 className="text-xl font-bold text-gray-900 mb-2">페이지를 찾을 수 없습니다</h2>
+        <p className="text-sm text-gray-500 mb-6">요청하신 페이지가 존재하지 않습니다.</p>
+        <Link href="/">
+          <Button>홈으로 돌아가기</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/home/app/(main)/loading.tsx
+++ b/apps/home/app/(main)/loading.tsx
@@ -1,0 +1,24 @@
+import { Skeleton } from "@shinhanqna/ui";
+
+export default function MainLoading() {
+  return (
+    <div className="flex flex-col">
+      <div className="flex border-b border-gray-200 px-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-20 mx-2 my-1 rounded-md" />
+        ))}
+      </div>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="flex gap-3 px-4 py-3 border-b border-gray-200">
+          <Skeleton className="h-10 w-10 rounded-full shrink-0" />
+          <div className="flex-1 flex flex-col gap-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-5 w-3/4" />
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-1/2" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/home/app/(main)/post/[postId]/loading.tsx
+++ b/apps/home/app/(main)/post/[postId]/loading.tsx
@@ -1,0 +1,26 @@
+import { Skeleton } from "@shinhanqna/ui";
+
+export default function PostLoading() {
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200">
+        <Skeleton className="h-5 w-5 rounded" />
+        <Skeleton className="h-5 w-16" />
+      </div>
+      <div className="px-4 py-4">
+        <div className="flex items-center gap-3 mb-4">
+          <Skeleton className="h-12 w-12 rounded-full" />
+          <div className="flex flex-col gap-1.5">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-3 w-32" />
+          </div>
+        </div>
+        <Skeleton className="h-7 w-3/4 mb-3" />
+        <Skeleton className="h-4 w-full mb-2" />
+        <Skeleton className="h-4 w-full mb-2" />
+        <Skeleton className="h-4 w-2/3 mb-6" />
+        <Skeleton className="h-8 w-24" />
+      </div>
+    </div>
+  );
+}

--- a/apps/home/app/error.tsx
+++ b/apps/home/app/error.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@shinhanqna/ui";
+
+export default function Error({ reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="flex flex-col items-center text-center">
+        <AlertTriangle className="h-12 w-12 text-orange-500 mb-4" />
+        <h2 className="text-xl font-bold text-gray-900 mb-2">문제가 발생했습니다</h2>
+        <p className="text-sm text-gray-500 mb-6">잠시 후 다시 시도해주세요.</p>
+        <Button onClick={reset}>다시 시도</Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/home/app/not-found.tsx
+++ b/apps/home/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { FileQuestion } from "lucide-react";
+import { Button } from "@shinhanqna/ui";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="flex flex-col items-center text-center">
+        <FileQuestion className="h-12 w-12 text-gray-300 mb-4" />
+        <h2 className="text-xl font-bold text-gray-900 mb-2">페이지를 찾을 수 없습니다</h2>
+        <p className="text-sm text-gray-500 mb-6">요청하신 페이지가 존재하지 않습니다.</p>
+        <Link href="/">
+          <Button>홈으로 돌아가기</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/layouts/three-column-layout.tsx
+++ b/packages/ui/src/layouts/three-column-layout.tsx
@@ -11,14 +11,14 @@ interface ThreeColumnLayoutProps {
 function ThreeColumnLayout({ left, center, right, className }: ThreeColumnLayoutProps) {
   return (
     <div className={cn("flex min-h-screen justify-center", className)}>
-      <div className="hidden lg:block sticky top-0 h-screen shrink-0">
+      <div className="hidden lg:flex sticky top-0 h-screen shrink-0 overflow-y-auto">
         {left}
       </div>
-      <main className="w-full max-w-[600px] border-x border-gray-200">
+      <main className="w-full lg:max-w-[600px] lg:border-x border-gray-200 pb-16 lg:pb-0">
         {center}
       </main>
       {right && (
-        <div className="hidden xl:block w-[350px] shrink-0 sticky top-0 h-screen">
+        <div className="hidden xl:flex w-[350px] shrink-0 sticky top-0 h-screen overflow-y-auto p-4">
           {right}
         </div>
       )}


### PR DESCRIPTION
## 연관 Issue
- closes #7

## 요약
반응형 레이아웃과 loading/error/not-found 상태 처리를 추가합니다.

## 변경 사항
- ThreeColumnLayout: 모바일 full-width, lg에서 sidebar 표시, xl에서 right sidebar 표시, 하단 패딩
- Home 피드 Skeleton 로딩 UI
- 게시글 상세 Skeleton 로딩 UI
- Admin 대시보드 Skeleton 로딩 UI
- error.tsx 에러 바운더리 (both apps)
- not-found.tsx 404 페이지 (both apps)

## 범위
### 포함:
- 반응형 breakpoint + loading/error/not-found

### 제외:
- 컴포넌트 디자인 개선 (Phase 8)