### PR TITLE
[Design/#14] 컴포넌트 디자인 다듬기 및 다크모드 대응

### DIFF
--- a/apps/admin/app/(auth)/layout.tsx
+++ b/apps/admin/app/(auth)/layout.tsx
@@ -2,11 +2,11 @@ import { Logo } from "@shinhanqna/ui";
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-screen items-center justify-center px-4">
-      <div className="w-full max-w-md">
-        <div className="flex flex-col items-center mb-8">
-          <Logo size={48} className="text-cyan-500 mb-3" />
-          <h1 className="text-2xl font-bold text-gray-900">신한Q&A 관리자</h1>
+    <div className="flex min-h-screen items-center justify-center px-4 bg-surface">
+      <div className="w-full max-w-sm">
+        <div className="flex flex-col items-center mb-10">
+          <Logo size={56} className="text-cyan-500 mb-4" />
+          <h1 className="text-2xl font-bold text-fg tracking-tight">신한Q&A</h1>
         </div>
         {children}
       </div>

--- a/apps/admin/app/(dashboard)/layout.tsx
+++ b/apps/admin/app/(dashboard)/layout.tsx
@@ -39,17 +39,17 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         header={
           <Link href="/" className="flex items-center gap-2">
             <Logo size={28} className="text-cyan-500" />
-            <span className="text-lg font-bold text-gray-900">관리자</span>
+            <span className="text-lg font-bold text-fg">관리자</span>
           </Link>
         }
         footer={
-          <Button variant="ghost" onClick={handleLogout} className="w-full text-gray-500 justify-start">
+          <Button variant="ghost" onClick={handleLogout} className="w-full text-fg-muted justify-start">
             <LogOut className="h-4 w-4 mr-2" />
             로그아웃
           </Button>
         }
       />
-      <main className="flex-1 bg-gray-100">
+      <main className="flex-1 bg-surface-hover">
         {children}
       </main>
     </div>

--- a/apps/admin/app/(dashboard)/page.tsx
+++ b/apps/admin/app/(dashboard)/page.tsx
@@ -12,32 +12,32 @@ export default function DashboardPage() {
 
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">대시보드</h1>
+      <h1 className="text-2xl font-bold text-fg mb-6">대시보드</h1>
 
       {isLoading ? (
         <div className="flex justify-center py-16"><Spinner size="lg" /></div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="rounded-xl bg-white p-6 shadow-card">
+          <div className="rounded-xl bg-surface p-6 shadow-card">
             <div className="flex items-center gap-3 mb-2">
               <div className="rounded-lg bg-orange-100 p-2">
                 <FileWarning className="h-5 w-5 text-orange-500" />
               </div>
-              <h2 className="text-base font-semibold text-gray-900">게시글 신고</h2>
+              <h2 className="text-base font-semibold text-fg">게시글 신고</h2>
             </div>
-            <p className="text-3xl font-bold text-gray-900">{postReports?.totalElements ?? 0}</p>
-            <p className="text-sm text-gray-500 mt-1">전체 신고 건수</p>
+            <p className="text-3xl font-bold text-fg">{postReports?.totalElements ?? 0}</p>
+            <p className="text-sm text-fg-muted mt-1">전체 신고 건수</p>
           </div>
 
-          <div className="rounded-xl bg-white p-6 shadow-card">
+          <div className="rounded-xl bg-surface p-6 shadow-card">
             <div className="flex items-center gap-3 mb-2">
               <div className="rounded-lg bg-red-100 p-2">
                 <MessageSquareWarning className="h-5 w-5 text-red-500" />
               </div>
-              <h2 className="text-base font-semibold text-gray-900">댓글 신고</h2>
+              <h2 className="text-base font-semibold text-fg">댓글 신고</h2>
             </div>
-            <p className="text-3xl font-bold text-gray-900">{commentReports?.totalElements ?? 0}</p>
-            <p className="text-sm text-gray-500 mt-1">전체 신고 건수</p>
+            <p className="text-3xl font-bold text-fg">{commentReports?.totalElements ?? 0}</p>
+            <p className="text-sm text-fg-muted mt-1">전체 신고 건수</p>
           </div>
         </div>
       )}

--- a/apps/admin/app/(dashboard)/reports/comments/page.tsx
+++ b/apps/admin/app/(dashboard)/reports/comments/page.tsx
@@ -28,7 +28,7 @@ export default function CommentReportsPage() {
 
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">댓글 신고 관리</h1>
+      <h1 className="text-2xl font-bold text-fg mb-6">댓글 신고 관리</h1>
 
       {isLoading ? (
         <div className="flex justify-center py-16"><Spinner size="lg" /></div>
@@ -36,9 +36,9 @@ export default function CommentReportsPage() {
         <EmptyState message="신고된 댓글이 없습니다" />
       ) : (
         <>
-          <div className="rounded-xl bg-white shadow-card overflow-hidden">
+          <div className="rounded-xl bg-surface shadow-card overflow-hidden">
             <table className="w-full text-sm">
-              <thead className="bg-gray-100 text-gray-600">
+              <thead className="bg-surface-hover text-fg-muted">
                 <tr>
                   <th className="text-left px-4 py-3 font-medium">댓글 ID</th>
                   <th className="text-left px-4 py-3 font-medium">게시글 ID</th>
@@ -49,22 +49,22 @@ export default function CommentReportsPage() {
                   <th className="text-right px-4 py-3 font-medium">관리</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-200">
+              <tbody className="divide-y divide-border-default">
                 {data.items.map((report) => (
-                  <tr key={report.reportId} className="hover:bg-gray-100 transition-colors">
-                    <td className="px-4 py-3 text-gray-900">{report.commentId}</td>
-                    <td className="px-4 py-3 text-gray-600">{report.postId}</td>
+                  <tr key={report.reportId} className="hover:bg-surface-hover transition-colors">
+                    <td className="px-4 py-3 text-fg">{report.commentId}</td>
+                    <td className="px-4 py-3 text-fg-muted">{report.postId}</td>
                     <td className="px-4 py-3">
                       <Badge variant="orange">{reasonLabels[report.reason]}</Badge>
                     </td>
-                    <td className="px-4 py-3 text-gray-600 max-w-[200px] truncate">{report.description || "-"}</td>
+                    <td className="px-4 py-3 text-fg-muted max-w-[200px] truncate">{report.description || "-"}</td>
                     <td className="px-4 py-3">
                       {report.commentDeleted
                         ? <Badge variant="default">삭제됨</Badge>
                         : <Badge variant="red">미처리</Badge>
                       }
                     </td>
-                    <td className="px-4 py-3 text-gray-500">{new Date(report.reportedAt).toLocaleDateString("ko-KR")}</td>
+                    <td className="px-4 py-3 text-fg-muted">{new Date(report.reportedAt).toLocaleDateString("ko-KR")}</td>
                     <td className="px-4 py-3 text-right">
                       {!report.commentDeleted && (
                         <Button
@@ -92,7 +92,7 @@ export default function CommentReportsPage() {
       )}
 
       <Modal open={deleteTarget !== null} onClose={() => setDeleteTarget(null)} title="댓글 삭제">
-        <p className="text-sm text-gray-600 mb-4">이 댓글을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</p>
+        <p className="text-sm text-fg-muted mb-4">이 댓글을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</p>
         <div className="flex justify-end gap-2">
           <Button variant="ghost" onClick={() => setDeleteTarget(null)}>취소</Button>
           <Button variant="danger" onClick={handleDelete} loading={deleteMutation.isPending}>삭제</Button>

--- a/apps/admin/app/(dashboard)/reports/posts/page.tsx
+++ b/apps/admin/app/(dashboard)/reports/posts/page.tsx
@@ -28,7 +28,7 @@ export default function PostReportsPage() {
 
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">게시글 신고 관리</h1>
+      <h1 className="text-2xl font-bold text-fg mb-6">게시글 신고 관리</h1>
 
       {isLoading ? (
         <div className="flex justify-center py-16"><Spinner size="lg" /></div>
@@ -36,9 +36,9 @@ export default function PostReportsPage() {
         <EmptyState message="신고된 게시글이 없습니다" />
       ) : (
         <>
-          <div className="rounded-xl bg-white shadow-card overflow-hidden">
+          <div className="rounded-xl bg-surface shadow-card overflow-hidden">
             <table className="w-full text-sm">
-              <thead className="bg-gray-100 text-gray-600">
+              <thead className="bg-surface-hover text-fg-muted">
                 <tr>
                   <th className="text-left px-4 py-3 font-medium">게시글 ID</th>
                   <th className="text-left px-4 py-3 font-medium">사유</th>
@@ -48,21 +48,21 @@ export default function PostReportsPage() {
                   <th className="text-right px-4 py-3 font-medium">관리</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-200">
+              <tbody className="divide-y divide-border-default">
                 {data.items.map((report) => (
-                  <tr key={report.reportId} className="hover:bg-gray-100 transition-colors">
-                    <td className="px-4 py-3 text-gray-900">{report.postId}</td>
+                  <tr key={report.reportId} className="hover:bg-surface-hover transition-colors">
+                    <td className="px-4 py-3 text-fg">{report.postId}</td>
                     <td className="px-4 py-3">
                       <Badge variant="orange">{reasonLabels[report.reason]}</Badge>
                     </td>
-                    <td className="px-4 py-3 text-gray-600 max-w-[200px] truncate">{report.description || "-"}</td>
+                    <td className="px-4 py-3 text-fg-muted max-w-[200px] truncate">{report.description || "-"}</td>
                     <td className="px-4 py-3">
                       {report.postDeleted
                         ? <Badge variant="default">삭제됨</Badge>
                         : <Badge variant="red">미처리</Badge>
                       }
                     </td>
-                    <td className="px-4 py-3 text-gray-500">{new Date(report.reportedAt).toLocaleDateString("ko-KR")}</td>
+                    <td className="px-4 py-3 text-fg-muted">{new Date(report.reportedAt).toLocaleDateString("ko-KR")}</td>
                     <td className="px-4 py-3 text-right">
                       {!report.postDeleted && (
                         <Button
@@ -90,7 +90,7 @@ export default function PostReportsPage() {
       )}
 
       <Modal open={deleteTarget !== null} onClose={() => setDeleteTarget(null)} title="게시글 삭제">
-        <p className="text-sm text-gray-600 mb-4">이 게시글을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</p>
+        <p className="text-sm text-fg-muted mb-4">이 게시글을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.</p>
         <div className="flex justify-end gap-2">
           <Button variant="ghost" onClick={() => setDeleteTarget(null)}>취소</Button>
           <Button variant="danger" onClick={handleDelete} loading={deleteMutation.isPending}>삭제</Button>

--- a/apps/admin/app/error.tsx
+++ b/apps/admin/app/error.tsx
@@ -8,8 +8,8 @@ export default function Error({ reset }: { error: Error; reset: () => void }) {
     <div className="flex min-h-screen items-center justify-center px-4">
       <div className="flex flex-col items-center text-center">
         <AlertTriangle className="h-12 w-12 text-orange-500 mb-4" />
-        <h2 className="text-xl font-bold text-gray-900 mb-2">문제가 발생했습니다</h2>
-        <p className="text-sm text-gray-500 mb-6">잠시 후 다시 시도해주세요.</p>
+        <h2 className="text-xl font-bold text-fg mb-2">문제가 발생했습니다</h2>
+        <p className="text-sm text-fg-muted mb-6">잠시 후 다시 시도해주세요.</p>
         <Button onClick={reset}>다시 시도</Button>
       </div>
     </div>

--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -1,3 +1,5 @@
 @import "tailwindcss";
 @import "pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css";
 @import "@shinhanqna/ui/theme";
+
+@source "../../../packages/ui/src";

--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body className="font-sans antialiased bg-gray-100 text-gray-900">
+      <body className="font-sans antialiased bg-canvas text-fg">
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/apps/admin/app/not-found.tsx
+++ b/apps/admin/app/not-found.tsx
@@ -6,9 +6,9 @@ export default function NotFound() {
   return (
     <div className="flex min-h-screen items-center justify-center px-4">
       <div className="flex flex-col items-center text-center">
-        <FileQuestion className="h-12 w-12 text-gray-300 mb-4" />
-        <h2 className="text-xl font-bold text-gray-900 mb-2">페이지를 찾을 수 없습니다</h2>
-        <p className="text-sm text-gray-500 mb-6">요청하신 페이지가 존재하지 않습니다.</p>
+        <FileQuestion className="h-12 w-12 text-fg-subtle mb-4" />
+        <h2 className="text-xl font-bold text-fg mb-2">페이지를 찾을 수 없습니다</h2>
+        <p className="text-sm text-fg-muted mb-6">요청하신 페이지가 존재하지 않습니다.</p>
         <Link href="/">
           <Button>홈으로 돌아가기</Button>
         </Link>

--- a/apps/home/app/(auth)/layout.tsx
+++ b/apps/home/app/(auth)/layout.tsx
@@ -2,11 +2,11 @@ import { Logo } from "@shinhanqna/ui";
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex min-h-screen items-center justify-center px-4">
-      <div className="w-full max-w-md">
-        <div className="flex flex-col items-center mb-8">
-          <Logo size={48} className="text-cyan-500 mb-3" />
-          <h1 className="text-2xl font-bold text-gray-900">신한Q&A</h1>
+    <div className="flex min-h-screen items-center justify-center px-4 bg-surface">
+      <div className="w-full max-w-sm">
+        <div className="flex flex-col items-center mb-10">
+          <Logo size={56} className="text-cyan-500 mb-4" />
+          <h1 className="text-2xl font-bold text-fg tracking-tight">신한Q&A</h1>
         </div>
         {children}
       </div>

--- a/apps/home/app/(auth)/login/page.tsx
+++ b/apps/home/app/(auth)/login/page.tsx
@@ -52,7 +52,7 @@ export default function LoginPage() {
       <Button type="submit" loading={loginMutation.isPending} className="w-full mt-2">
         로그인
       </Button>
-      <p className="text-center text-sm text-gray-500">
+      <p className="text-center text-sm text-fg-muted">
         계정이 없으신가요?{" "}
         <Link href="/register" className="text-cyan-500 font-medium hover:underline">
           회원가입

--- a/apps/home/app/(auth)/register/page.tsx
+++ b/apps/home/app/(auth)/register/page.tsx
@@ -68,7 +68,7 @@ export default function RegisterPage() {
       <Button type="submit" loading={registerMutation.isPending} className="w-full mt-2">
         회원가입
       </Button>
-      <p className="text-center text-sm text-gray-500">
+      <p className="text-center text-sm text-fg-muted">
         이미 계정이 있으신가요?{" "}
         <Link href="/login" className="text-cyan-500 font-medium hover:underline">
           로그인

--- a/apps/home/app/(main)/board/[boardType]/page.tsx
+++ b/apps/home/app/(main)/board/[boardType]/page.tsx
@@ -34,8 +34,8 @@ export default function BoardPage() {
 
   return (
     <div className="flex flex-col">
-      <div className="px-4 py-3 border-b border-gray-200">
-        <h2 className="text-lg font-bold text-gray-900">{boardTitles[boardType]}</h2>
+      <div className="px-4 py-3 border-b border-border-default">
+        <h2 className="text-lg font-bold text-fg">{boardTitles[boardType]}</h2>
       </div>
 
       {isLoading ? (

--- a/apps/home/app/(main)/layout.tsx
+++ b/apps/home/app/(main)/layout.tsx
@@ -38,7 +38,7 @@ export default function MainLayout({ children }: { children: React.ReactNode }) 
             header={
               <Link href="/" className="flex items-center gap-2">
                 <Logo size={28} className="text-cyan-500" />
-                <span className="text-lg font-bold text-gray-900">신한Q&A</span>
+                <span className="text-lg font-bold text-fg">신한Q&A</span>
               </Link>
             }
           />

--- a/apps/home/app/(main)/loading.tsx
+++ b/apps/home/app/(main)/loading.tsx
@@ -3,13 +3,13 @@ import { Skeleton } from "@shinhanqna/ui";
 export default function MainLoading() {
   return (
     <div className="flex flex-col">
-      <div className="flex border-b border-gray-200 px-2">
+      <div className="flex border-b border-border-default px-2">
         {Array.from({ length: 4 }).map((_, i) => (
           <Skeleton key={i} className="h-10 w-20 mx-2 my-1 rounded-md" />
         ))}
       </div>
       {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="flex gap-3 px-4 py-3 border-b border-gray-200">
+        <div key={i} className="flex gap-3 px-4 py-3 border-b border-border-default">
           <Skeleton className="h-10 w-10 rounded-full shrink-0" />
           <div className="flex-1 flex flex-col gap-2">
             <Skeleton className="h-4 w-32" />

--- a/apps/home/app/(main)/post/[postId]/edit/page.tsx
+++ b/apps/home/app/(main)/post/[postId]/edit/page.tsx
@@ -54,11 +54,11 @@ export default function EditPostPage() {
 
   return (
     <div className="flex flex-col">
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200">
-        <button type="button" onClick={() => router.back()} className="text-gray-500 hover:text-gray-700">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-border-default">
+        <button type="button" onClick={() => router.back()} className="text-fg-muted hover:text-fg">
           <ArrowLeft className="h-5 w-5" />
         </button>
-        <span className="text-lg font-bold text-gray-900">수정하기</span>
+        <span className="text-lg font-bold text-fg">수정하기</span>
       </div>
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">

--- a/apps/home/app/(main)/post/[postId]/loading.tsx
+++ b/apps/home/app/(main)/post/[postId]/loading.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@shinhanqna/ui";
 export default function PostLoading() {
   return (
     <div className="flex flex-col">
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-border-default">
         <Skeleton className="h-5 w-5 rounded" />
         <Skeleton className="h-5 w-16" />
       </div>

--- a/apps/home/app/(main)/post/[postId]/page.tsx
+++ b/apps/home/app/(main)/post/[postId]/page.tsx
@@ -61,11 +61,11 @@ export default function PostDetailPage() {
 
   return (
     <div className="flex flex-col">
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200">
-        <button type="button" onClick={() => router.back()} className="text-gray-500 hover:text-gray-700">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-border-default">
+        <button type="button" onClick={() => router.back()} className="text-fg-muted hover:text-fg">
           <ArrowLeft className="h-5 w-5" />
         </button>
-        <span className="text-lg font-bold text-gray-900">게시글</span>
+        <span className="text-lg font-bold text-fg">게시글</span>
       </div>
 
       <article className="px-4 py-4">
@@ -73,15 +73,15 @@ export default function PostDetailPage() {
           <div className="flex items-center gap-3">
             <Avatar fallback={post.authorName} size="lg" />
             <div>
-              <p className="font-semibold text-gray-900">{post.authorName}</p>
+              <p className="font-semibold text-fg">{post.authorName}</p>
               <div className="flex items-center gap-2">
                 <Badge variant="cyan">{boardLabels[post.boardType]}</Badge>
-                <span className="text-xs text-gray-500">{new Date(post.createdAt).toLocaleDateString("ko-KR")}</span>
+                <span className="text-xs text-fg-muted">{new Date(post.createdAt).toLocaleDateString("ko-KR")}</span>
               </div>
             </div>
           </div>
           <Dropdown
-            trigger={<MoreHorizontal className="h-5 w-5 text-gray-500" />}
+            trigger={<MoreHorizontal className="h-5 w-5 text-fg-muted" />}
             items={[
               { key: "edit", label: "수정" },
               { key: "report", label: "신고" },
@@ -95,8 +95,8 @@ export default function PostDetailPage() {
           />
         </div>
 
-        <h1 className="text-xl font-bold text-gray-900 mb-2">{post.title}</h1>
-        <p className="text-base text-gray-700 whitespace-pre-wrap mb-4">{post.content}</p>
+        <h1 className="text-xl font-bold text-fg mb-2">{post.title}</h1>
+        <p className="text-base text-fg whitespace-pre-wrap mb-4">{post.content}</p>
 
         {post.imageUrls.length > 0 && (
           <div className="flex gap-2 overflow-x-auto mb-4">
@@ -117,7 +117,7 @@ export default function PostDetailPage() {
           </div>
         )}
 
-        <div className="flex items-center gap-3 py-3 border-t border-gray-200">
+        <div className="flex items-center gap-3 py-3 border-t border-border-default">
           <LikeButton
             liked={liked}
             count={post.likeCount}
@@ -128,9 +128,9 @@ export default function PostDetailPage() {
         </div>
       </article>
 
-      <div className="border-t border-gray-200">
+      <div className="border-t border-border-default">
         <div className="px-4 py-3">
-          <h2 className="text-base font-semibold text-gray-900">댓글 {post.commentCount}</h2>
+          <h2 className="text-base font-semibold text-fg">댓글 {post.commentCount}</h2>
         </div>
 
         <form onSubmit={handleComment} className="flex gap-2 px-4 pb-3">

--- a/apps/home/app/(main)/post/new/page.tsx
+++ b/apps/home/app/(main)/post/new/page.tsx
@@ -50,11 +50,11 @@ export default function NewPostPage() {
 
   return (
     <div className="flex flex-col">
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200">
-        <button type="button" onClick={() => router.back()} className="text-gray-500 hover:text-gray-700">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-border-default">
+        <button type="button" onClick={() => router.back()} className="text-fg-muted hover:text-fg">
           <ArrowLeft className="h-5 w-5" />
         </button>
-        <span className="text-lg font-bold text-gray-900">글쓰기</span>
+        <span className="text-lg font-bold text-fg">글쓰기</span>
       </div>
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
@@ -82,7 +82,7 @@ export default function NewPostPage() {
         />
 
         <div>
-          <label className="text-sm font-medium text-gray-700 mb-1.5 block">
+          <label className="text-sm font-medium text-fg mb-1.5 block">
             이미지 (최대 5장)
           </label>
           <input
@@ -90,13 +90,13 @@ export default function NewPostPage() {
             accept="image/*"
             multiple
             onChange={(e) => setImages(Array.from(e.target.files || []).slice(0, 5))}
-            className="text-sm text-gray-500 file:mr-3 file:rounded-lg file:border-0 file:bg-gray-100 file:px-4 file:py-2 file:text-sm file:font-medium file:text-gray-700 hover:file:bg-gray-200"
+            className="text-sm text-fg-muted file:mr-3 file:rounded-lg file:border-0 file:bg-surface-hover file:px-4 file:py-2 file:text-sm file:font-medium file:text-fg hover:file:bg-surface-hover"
           />
         </div>
 
         {isRecruitBoard(boardType) && (
-          <div className="flex flex-col gap-3 p-4 rounded-xl bg-gray-100">
-            <p className="text-sm font-semibold text-gray-900">모집 정보</p>
+          <div className="flex flex-col gap-3 p-4 rounded-xl bg-surface-hover">
+            <p className="text-sm font-semibold text-fg">모집 정보</p>
             <Input
               label="모집 인원"
               type="number"

--- a/apps/home/app/(main)/profile/page.tsx
+++ b/apps/home/app/(main)/profile/page.tsx
@@ -40,16 +40,16 @@ export default function ProfilePage() {
 
   return (
     <div className="flex flex-col">
-      <div className="px-4 py-3 border-b border-gray-200">
-        <h2 className="text-lg font-bold text-gray-900">프로필</h2>
+      <div className="px-4 py-3 border-b border-border-default">
+        <h2 className="text-lg font-bold text-fg">프로필</h2>
       </div>
 
       <div className="p-4 flex flex-col gap-6">
         <div className="flex items-center gap-4">
           <Avatar fallback="나" size="lg" />
           <div>
-            <p className="font-semibold text-gray-900">내 프로필</p>
-            <p className="text-sm text-gray-500">닉네임을 변경할 수 있습니다</p>
+            <p className="font-semibold text-fg">내 프로필</p>
+            <p className="text-sm text-fg-muted">닉네임을 변경할 수 있습니다</p>
           </div>
         </div>
 
@@ -68,7 +68,7 @@ export default function ProfilePage() {
           </Button>
         </form>
 
-        <div className="border-t border-gray-200 pt-4">
+        <div className="border-t border-border-default pt-4">
           <Button
             variant="ghost"
             onClick={handleLogout}

--- a/apps/home/app/error.tsx
+++ b/apps/home/app/error.tsx
@@ -8,8 +8,8 @@ export default function Error({ reset }: { error: Error; reset: () => void }) {
     <div className="flex min-h-screen items-center justify-center px-4">
       <div className="flex flex-col items-center text-center">
         <AlertTriangle className="h-12 w-12 text-orange-500 mb-4" />
-        <h2 className="text-xl font-bold text-gray-900 mb-2">문제가 발생했습니다</h2>
-        <p className="text-sm text-gray-500 mb-6">잠시 후 다시 시도해주세요.</p>
+        <h2 className="text-xl font-bold text-fg mb-2">문제가 발생했습니다</h2>
+        <p className="text-sm text-fg-muted mb-6">잠시 후 다시 시도해주세요.</p>
         <Button onClick={reset}>다시 시도</Button>
       </div>
     </div>

--- a/apps/home/app/globals.css
+++ b/apps/home/app/globals.css
@@ -1,3 +1,5 @@
 @import "tailwindcss";
 @import "pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css";
 @import "@shinhanqna/ui/theme";
+
+@source "../../../packages/ui/src";

--- a/apps/home/app/layout.tsx
+++ b/apps/home/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body className="font-sans antialiased bg-gray-100 text-gray-900">
+      <body className="font-sans antialiased bg-canvas text-fg">
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/apps/home/app/not-found.tsx
+++ b/apps/home/app/not-found.tsx
@@ -6,9 +6,9 @@ export default function NotFound() {
   return (
     <div className="flex min-h-screen items-center justify-center px-4">
       <div className="flex flex-col items-center text-center">
-        <FileQuestion className="h-12 w-12 text-gray-300 mb-4" />
-        <h2 className="text-xl font-bold text-gray-900 mb-2">페이지를 찾을 수 없습니다</h2>
-        <p className="text-sm text-gray-500 mb-6">요청하신 페이지가 존재하지 않습니다.</p>
+        <FileQuestion className="h-12 w-12 text-fg-subtle mb-4" />
+        <h2 className="text-xl font-bold text-fg mb-2">페이지를 찾을 수 없습니다</h2>
+        <p className="text-sm text-fg-muted mb-6">요청하신 페이지가 존재하지 않습니다.</p>
         <Link href="/">
           <Button>홈으로 돌아가기</Button>
         </Link>

--- a/packages/ui/src/composites/comment-item.tsx
+++ b/packages/ui/src/composites/comment-item.tsx
@@ -35,16 +35,16 @@ function CommentItem({
       <Avatar fallback={anonymousLabel} size="sm" className="shrink-0" />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1">
-          <span className="text-sm font-semibold text-gray-900">{anonymousLabel}</span>
+          <span className="text-sm font-semibold text-fg">{anonymousLabel}</span>
           {isPostAuthor && <Badge variant="cyan">작성자</Badge>}
-          <span className="text-xs text-gray-500">
+          <span className="text-xs text-fg-muted">
             {new Date(createdAt).toLocaleDateString("ko-KR")}
           </span>
         </div>
         {deleted ? (
-          <p className="text-sm text-gray-400 italic">삭제된 댓글입니다.</p>
+          <p className="text-sm text-fg-subtle italic">삭제된 댓글입니다.</p>
         ) : (
-          <p className="text-sm text-gray-700 whitespace-pre-wrap">{content}</p>
+          <p className="text-sm text-fg whitespace-pre-wrap">{content}</p>
         )}
         {!deleted && actions && (
           <div className="flex items-center gap-2 mt-1.5">{actions}</div>

--- a/packages/ui/src/composites/empty-state.tsx
+++ b/packages/ui/src/composites/empty-state.tsx
@@ -10,10 +10,10 @@ interface EmptyStateProps {
 function EmptyState({ message, description, className }: EmptyStateProps) {
   return (
     <div className={cn("flex flex-col items-center justify-center py-16 text-center", className)}>
-      <Inbox className="h-12 w-12 text-gray-300 mb-4" />
-      <p className="text-base font-medium text-gray-500">{message}</p>
+      <Inbox className="h-12 w-12 text-fg-subtle mb-4" />
+      <p className="text-base font-medium text-fg-muted">{message}</p>
       {description && (
-        <p className="text-sm text-gray-400 mt-1">{description}</p>
+        <p className="text-sm text-fg-subtle mt-1">{description}</p>
       )}
     </div>
   );

--- a/packages/ui/src/composites/like-button.tsx
+++ b/packages/ui/src/composites/like-button.tsx
@@ -20,8 +20,8 @@ function LikeButton({ liked, count, onClick, className }: LikeButtonProps) {
       className={cn(
         "flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm transition-colors",
         liked
-          ? "text-red-500 bg-red-100 hover:bg-red-200"
-          : "text-gray-500 hover:text-red-500 hover:bg-red-100",
+          ? "text-red-500 bg-red-100 hover:bg-red-200 dark:bg-red-800 dark:text-red-100 dark:hover:bg-red-700"
+          : "text-fg-muted hover:text-red-500 hover:bg-red-100 dark:hover:bg-red-800",
         className,
       )}
     >

--- a/packages/ui/src/composites/pagination.tsx
+++ b/packages/ui/src/composites/pagination.tsx
@@ -20,11 +20,11 @@ function Pagination({ page, totalPages, hasNext, hasPrevious, onPageChange, clas
         onClick={() => onPageChange(page - 1)}
         disabled={!hasPrevious}
         aria-label="이전 페이지"
-        className="p-2 rounded-lg text-gray-500 hover:bg-gray-100 disabled:opacity-30 disabled:pointer-events-none"
+        className="p-2 rounded-lg text-fg-muted hover:bg-surface-hover disabled:opacity-30 disabled:pointer-events-none"
       >
         <ChevronLeft className="h-5 w-5" aria-hidden="true" />
       </button>
-      <span className="text-sm text-gray-600 px-3">
+      <span className="text-sm text-fg-muted px-3">
         {page + 1} / {totalPages}
       </span>
       <button
@@ -32,7 +32,7 @@ function Pagination({ page, totalPages, hasNext, hasPrevious, onPageChange, clas
         onClick={() => onPageChange(page + 1)}
         disabled={!hasNext}
         aria-label="다음 페이지"
-        className="p-2 rounded-lg text-gray-500 hover:bg-gray-100 disabled:opacity-30 disabled:pointer-events-none"
+        className="p-2 rounded-lg text-fg-muted hover:bg-surface-hover disabled:opacity-30 disabled:pointer-events-none"
       >
         <ChevronRight className="h-5 w-5" aria-hidden="true" />
       </button>

--- a/packages/ui/src/composites/post-card.tsx
+++ b/packages/ui/src/composites/post-card.tsx
@@ -48,7 +48,7 @@ function PostCard({
       tabIndex={onClick ? 0 : undefined}
       role={onClick ? "button" : undefined}
       className={cn(
-        "flex gap-3 px-4 py-3 border-b border-gray-200 transition-colors hover:bg-gray-100",
+        "flex gap-3 px-4 py-3 border-b border-border-default transition-colors hover:bg-surface-hover",
         onClick && "cursor-pointer",
         className,
       )}
@@ -56,20 +56,20 @@ function PostCard({
       <Avatar fallback={authorName} size="md" className="shrink-0" />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1">
-          <span className="text-sm font-semibold text-gray-900 truncate">{authorName}</span>
+          <span className="text-sm font-semibold text-fg truncate">{authorName}</span>
           <Badge variant={boardVariants[boardType]}>{boardLabels[boardType]}</Badge>
-          <span className="text-xs text-gray-500 shrink-0">
+          <span className="text-xs text-fg-subtle shrink-0">
             {new Date(createdAt).toLocaleDateString("ko-KR")}
           </span>
         </div>
-        <h3 className="text-base font-semibold text-gray-900 mb-1 truncate">{title}</h3>
-        <p className="text-sm text-gray-600 line-clamp-2">{content}</p>
+        <h3 className="text-base font-semibold text-fg mb-1 truncate">{title}</h3>
+        <p className="text-sm text-fg-muted line-clamp-2">{content}</p>
         <div className="flex items-center gap-4 mt-2">
-          <span className="flex items-center gap-1 text-xs text-gray-500">
+          <span className="flex items-center gap-1 text-xs text-fg-subtle">
             <Heart className="h-3.5 w-3.5" />
             {likeCount}
           </span>
-          <span className="flex items-center gap-1 text-xs text-gray-500">
+          <span className="flex items-center gap-1 text-xs text-fg-subtle">
             <MessageCircle className="h-3.5 w-3.5" />
             {commentCount}
           </span>

--- a/packages/ui/src/composites/recruitment-badge.tsx
+++ b/packages/ui/src/composites/recruitment-badge.tsx
@@ -25,11 +25,11 @@ function RecruitmentBadge({
       <Badge variant={isClosed ? "default" : "green"}>
         {isClosed ? "모집 마감" : "모집 중"}
       </Badge>
-      <span className="flex items-center gap-1 text-xs text-gray-500">
+      <span className="flex items-center gap-1 text-xs text-fg-muted">
         <Users className="h-3.5 w-3.5" />
         {currentCount}/{capacity}
       </span>
-      <span className="flex items-center gap-1 text-xs text-gray-500">
+      <span className="flex items-center gap-1 text-xs text-fg-muted">
         <Calendar className="h-3.5 w-3.5" />
         {new Date(deadline).toLocaleDateString("ko-KR")}
       </span>

--- a/packages/ui/src/composites/report-dialog.tsx
+++ b/packages/ui/src/composites/report-dialog.tsx
@@ -49,8 +49,8 @@ function ReportDialog({ open, onClose, onSubmit, loading }: ReportDialogProps) {
               className={cn(
                 "px-4 py-3 rounded-lg border text-left text-sm transition-colors",
                 reason === r.value
-                  ? "border-cyan-500 bg-cyan-100 text-cyan-900"
-                  : "border-gray-200 text-gray-700 hover:bg-gray-100",
+                  ? "border-cyan-500 bg-cyan-100 text-cyan-900 dark:bg-cyan-800 dark:text-cyan-100"
+                  : "border-border-default text-fg hover:bg-surface-hover",
               )}
             >
               {r.label}

--- a/packages/ui/src/layouts/header.tsx
+++ b/packages/ui/src/layouts/header.tsx
@@ -12,13 +12,13 @@ function Header({ title, left, right, className }: HeaderProps) {
   return (
     <header
       className={cn(
-        "sticky top-0 z-40 flex items-center justify-between h-14 px-4 border-b border-gray-200 bg-white/80 backdrop-blur-sm",
+        "sticky top-0 z-40 flex items-center justify-between h-14 px-4 border-b border-border-default bg-surface/80 backdrop-blur-sm",
         className,
       )}
     >
       <div className="flex items-center gap-3">
         {left}
-        <h1 className="text-lg font-bold text-gray-900">{title}</h1>
+        <h1 className="text-lg font-bold text-fg">{title}</h1>
       </div>
       {right && <div className="flex items-center gap-2">{right}</div>}
     </header>

--- a/packages/ui/src/layouts/mobile-nav.tsx
+++ b/packages/ui/src/layouts/mobile-nav.tsx
@@ -20,7 +20,7 @@ function MobileNav({ items, activeKey, className }: MobileNavProps) {
   return (
     <nav
       className={cn(
-        "fixed bottom-0 left-0 right-0 z-50 flex items-center justify-around border-t border-gray-200 bg-white py-2 lg:hidden",
+        "fixed bottom-0 left-0 right-0 z-50 flex items-center justify-around border-t border-border-default bg-surface py-2 lg:hidden",
         className,
       )}
     >
@@ -33,7 +33,7 @@ function MobileNav({ items, activeKey, className }: MobileNavProps) {
             "flex flex-col items-center gap-0.5 px-3 py-1 text-xs transition-colors",
             activeKey === item.key
               ? "text-cyan-500"
-              : "text-gray-500",
+              : "text-fg-subtle",
           )}
         >
           {item.icon}

--- a/packages/ui/src/layouts/sidebar.tsx
+++ b/packages/ui/src/layouts/sidebar.tsx
@@ -20,8 +20,8 @@ interface SidebarProps {
 
 function Sidebar({ links, activeKey, header, footer, className }: SidebarProps) {
   return (
-    <aside className={cn("flex flex-col h-full w-[240px] border-r border-gray-200 bg-white", className)}>
-      {header && <div className="p-4 border-b border-gray-200">{header}</div>}
+    <aside className={cn("flex flex-col h-full w-[240px] border-r border-border-default bg-surface", className)}>
+      {header && <div className="p-4 border-b border-border-default">{header}</div>}
       <nav className="flex-1 py-2">
         {links.map((link) => (
           <a
@@ -32,7 +32,7 @@ function Sidebar({ links, activeKey, header, footer, className }: SidebarProps) 
               "flex items-center gap-3 mx-2 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors",
               activeKey === link.key
                 ? "bg-cyan-100 text-cyan-900"
-                : "text-gray-600 hover:bg-gray-100 hover:text-gray-900",
+                : "text-fg-muted hover:bg-surface-hover hover:text-fg",
             )}
           >
             {link.icon}
@@ -40,7 +40,7 @@ function Sidebar({ links, activeKey, header, footer, className }: SidebarProps) 
           </a>
         ))}
       </nav>
-      {footer && <div className="p-4 border-t border-gray-200">{footer}</div>}
+      {footer && <div className="p-4 border-t border-border-default">{footer}</div>}
     </aside>
   );
 }

--- a/packages/ui/src/layouts/three-column-layout.tsx
+++ b/packages/ui/src/layouts/three-column-layout.tsx
@@ -14,7 +14,7 @@ function ThreeColumnLayout({ left, center, right, className }: ThreeColumnLayout
       <div className="hidden lg:flex sticky top-0 h-screen shrink-0 overflow-y-auto">
         {left}
       </div>
-      <main className="w-full lg:max-w-[600px] lg:border-x border-gray-200 pb-16 lg:pb-0">
+      <main className="w-full lg:max-w-[600px] lg:border-x border-border-default pb-16 lg:pb-0">
         {center}
       </main>
       {right && (

--- a/packages/ui/src/primitives/avatar.tsx
+++ b/packages/ui/src/primitives/avatar.tsx
@@ -23,7 +23,8 @@ function Avatar({ src, fallback, size = "md", className }: AvatarProps) {
       <img
         src={src}
         alt={fallback}
-        className={cn("rounded-full object-cover", sizeStyles[size], className)}
+        draggable={false}
+        className={cn("rounded-full object-cover select-none", sizeStyles[size], className)}
       />
     );
   }
@@ -31,7 +32,7 @@ function Avatar({ src, fallback, size = "md", className }: AvatarProps) {
   return (
     <div
       className={cn(
-        "rounded-full bg-cyan-100 text-cyan-700 flex items-center justify-center font-semibold",
+        "rounded-full bg-cyan-100 text-cyan-700 dark:bg-cyan-800 dark:text-cyan-100 flex items-center justify-center font-semibold select-none",
         sizeStyles[size],
         className,
       )}

--- a/packages/ui/src/primitives/badge.tsx
+++ b/packages/ui/src/primitives/badge.tsx
@@ -8,12 +8,12 @@ interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
 }
 
 const variantStyles: Record<BadgeVariant, string> = {
-  default: "bg-gray-100 text-gray-700",
-  cyan: "bg-cyan-100 text-cyan-900",
-  blue: "bg-blue-100 text-blue-900",
-  red: "bg-red-100 text-red-900",
-  orange: "bg-orange-100 text-orange-900",
-  green: "bg-green-100 text-green-900",
+  default: "bg-surface-hover text-fg-muted",
+  cyan: "bg-cyan-100 text-cyan-900 dark:bg-cyan-800 dark:text-cyan-100",
+  blue: "bg-blue-100 text-blue-900 dark:bg-blue-800 dark:text-blue-100",
+  red: "bg-red-100 text-red-900 dark:bg-red-800 dark:text-red-100",
+  orange: "bg-orange-100 text-orange-900 dark:bg-orange-800 dark:text-orange-100",
+  green: "bg-green-100 text-green-900 dark:bg-green-800 dark:text-green-100",
 };
 
 function Badge({ variant = "default", className, children, ...props }: BadgeProps) {

--- a/packages/ui/src/primitives/button.tsx
+++ b/packages/ui/src/primitives/button.tsx
@@ -12,16 +12,16 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 const variantStyles: Record<ButtonVariant, string> = {
-  primary: "bg-cyan-500 text-white hover:bg-cyan-600 active:bg-cyan-700",
-  secondary: "bg-gray-100 text-gray-900 hover:bg-gray-200 active:bg-gray-300 border border-gray-300",
-  ghost: "bg-transparent text-gray-700 hover:bg-gray-100 active:bg-gray-200",
-  danger: "bg-red-500 text-white hover:bg-red-600 active:bg-red-700",
+  primary: "bg-cyan-500 text-white hover:bg-cyan-600 active:bg-cyan-700 shadow-sm",
+  secondary: "bg-surface text-fg hover:bg-surface-hover active:bg-surface-hover border border-border-default shadow-sm",
+  ghost: "bg-transparent text-fg-muted hover:bg-surface-hover active:bg-surface-hover",
+  danger: "bg-red-500 text-white hover:bg-red-600 active:bg-red-700 shadow-sm",
 };
 
 const sizeStyles: Record<ButtonSize, string> = {
-  sm: "px-3 py-1.5 text-sm rounded-md",
-  md: "px-4 py-2 text-base rounded-lg",
-  lg: "px-6 py-3 text-md rounded-lg",
+  sm: "px-3.5 py-1.5 text-sm rounded-xl",
+  md: "px-5 py-2.5 text-base rounded-xl",
+  lg: "px-6 py-3 text-md rounded-xl",
 };
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(

--- a/packages/ui/src/primitives/dropdown.tsx
+++ b/packages/ui/src/primitives/dropdown.tsx
@@ -41,16 +41,24 @@ function Dropdown({ trigger, items, onSelect, className }: DropdownProps) {
 
   return (
     <div ref={ref} className={cn("relative inline-block", className)}>
-      <button
-        type="button"
+      <span
+        role="button"
+        tabIndex={0}
         onClick={() => setOpen(!open)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setOpen(!open);
+          }
+        }}
         aria-expanded={open}
         aria-haspopup="menu"
+        className="inline-block cursor-pointer"
       >
         {trigger}
-      </button>
+      </span>
       {open && (
-        <div className="absolute right-0 top-full mt-1 min-w-[160px] rounded-xl border border-gray-200 bg-white py-1 shadow-dropdown z-50" role="menu">
+        <div className="absolute left-0 top-full mt-1 min-w-[160px] rounded-xl border border-border-default bg-surface py-1 shadow-dropdown z-50" role="menu">
           {items.map((item) => (
             <button
               key={item.key}
@@ -64,7 +72,7 @@ function Dropdown({ trigger, items, onSelect, className }: DropdownProps) {
                 "w-full px-4 py-2.5 text-left text-sm transition-colors",
                 item.danger
                   ? "text-red-500 hover:bg-red-100"
-                  : "text-gray-700 hover:bg-gray-100",
+                  : "text-fg hover:bg-surface-hover",
               )}
             >
               {item.label}

--- a/packages/ui/src/primitives/input.tsx
+++ b/packages/ui/src/primitives/input.tsx
@@ -14,7 +14,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
     return (
       <div className="flex flex-col gap-1.5">
         {label && (
-          <label htmlFor={inputId} className="text-sm font-medium text-gray-700">
+          <label htmlFor={inputId} className="text-sm font-medium text-fg-muted">
             {label}
           </label>
         )}
@@ -24,8 +24,8 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           aria-invalid={error ? "true" : undefined}
           aria-describedby={errorId}
           className={cn(
-            "w-full rounded-lg border bg-white px-4 py-2.5 text-base text-gray-900 placeholder:text-gray-500 transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent",
-            error ? "border-red-500" : "border-gray-300",
+            "w-full rounded-xl border-none bg-input px-4 py-3 text-base text-fg placeholder:text-fg-subtle transition-all outline-none ring-0 focus:ring-2 focus:ring-cyan-500/30 focus:bg-input-focus",
+            error && "ring-2 ring-red-500/30 bg-red-100/30",
             className,
           )}
           {...props}

--- a/packages/ui/src/primitives/modal.tsx
+++ b/packages/ui/src/primitives/modal.tsx
@@ -44,7 +44,7 @@ function Modal({ open, onClose, title, children, className }: ModalProps) {
       ref={dialogRef}
       aria-labelledby={title ? titleId : undefined}
       className={cn(
-        "rounded-2xl border-none bg-white p-0 shadow-modal backdrop:bg-black/50 max-w-lg w-full",
+        "rounded-2xl border-none bg-surface p-0 shadow-modal backdrop:bg-black/50 max-w-lg w-full m-auto",
         className,
       )}
       onClick={(e) => {
@@ -53,7 +53,7 @@ function Modal({ open, onClose, title, children, className }: ModalProps) {
     >
       <div className="p-6">
         {title && (
-          <h2 id={titleId} className="text-xl font-bold text-gray-900 mb-4">{title}</h2>
+          <h2 id={titleId} className="text-xl font-bold text-fg mb-4">{title}</h2>
         )}
         {children}
       </div>

--- a/packages/ui/src/primitives/skeleton.tsx
+++ b/packages/ui/src/primitives/skeleton.tsx
@@ -7,7 +7,7 @@ interface SkeletonProps {
 function Skeleton({ className }: SkeletonProps) {
   return (
     <div
-      className={cn("animate-pulse rounded-lg bg-gray-200", className)}
+      className={cn("animate-pulse rounded-lg bg-surface-hover", className)}
       aria-hidden="true"
     />
   );

--- a/packages/ui/src/primitives/tabs.tsx
+++ b/packages/ui/src/primitives/tabs.tsx
@@ -35,7 +35,7 @@ function Tabs({ items, activeKey, onChange, className }: TabsProps) {
   };
 
   return (
-    <div className={cn("flex border-b border-gray-200", className)} role="tablist">
+    <div className={cn("flex border-b border-border-default", className)} role="tablist">
       {items.map((item, index) => (
         <button
           key={item.key}
@@ -50,7 +50,7 @@ function Tabs({ items, activeKey, onChange, className }: TabsProps) {
             "px-4 py-3 text-sm font-medium transition-colors relative",
             activeKey === item.key
               ? "text-cyan-500"
-              : "text-gray-500 hover:text-gray-700",
+              : "text-fg-muted hover:text-fg",
           )}
         >
           {item.label}

--- a/packages/ui/src/primitives/textarea.tsx
+++ b/packages/ui/src/primitives/textarea.tsx
@@ -14,7 +14,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <div className="flex flex-col gap-1.5">
         {label && (
-          <label htmlFor={textareaId} className="text-sm font-medium text-gray-700">
+          <label htmlFor={textareaId} className="text-sm font-medium text-fg-muted">
             {label}
           </label>
         )}
@@ -24,8 +24,8 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           aria-invalid={error ? "true" : undefined}
           aria-describedby={errorId}
           className={cn(
-            "w-full rounded-lg border bg-white px-4 py-2.5 text-base text-gray-900 placeholder:text-gray-500 transition-colors resize-none focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:border-transparent",
-            error ? "border-red-500" : "border-gray-300",
+            "w-full rounded-xl border-none bg-input px-4 py-3 text-base text-fg placeholder:text-fg-subtle transition-all resize-none outline-none ring-0 focus:ring-2 focus:ring-cyan-500/30 focus:bg-input-focus",
+            error && "ring-2 ring-red-500/30 bg-red-100/30",
             className,
           )}
           rows={4}

--- a/packages/ui/src/theme/tokens.css
+++ b/packages/ui/src/theme/tokens.css
@@ -5,18 +5,19 @@
   --color-black: oklch(0.1776 0 0);
   --color-white: oklch(1 0 0);
 
-  /* Cyan (Primary) */
+  /* Cyan */
   --color-cyan-100: oklch(0.9700 0.0177 216.20);
   --color-cyan-200: oklch(0.9300 0.0251 216.20);
   --color-cyan-300: oklch(0.8800 0.0325 216.20);
   --color-cyan-400: oklch(0.8200 0.0399 216.20);
-  --color-cyan-500: oklch(0.6652 0.1183 216.20);
-  --color-cyan-600: oklch(0.5602 0.1267 216.20);
-  --color-cyan-700: oklch(0.4552 0.1301 216.20);
-  --color-cyan-800: oklch(0.3502 0.1267 216.20);
-  --color-cyan-900: oklch(0.2452 0.1183 216.20);
+  --color-cyan-500: oklch(0.6652 0.1002 216.20);
+  --color-cyan-600: oklch(0.5602 0.1002 216.20);
+  --color-cyan-700: oklch(0.4552 0.0819 216.20);
+  --color-cyan-800: oklch(0.3502 0.0639 216.20);
+  --color-cyan-900: oklch(0.2452 0.0468 216.20);
 
   /* Gray */
+  --color-gray-50: oklch(0.9850 0 0);
   --color-gray-100: oklch(0.9700 0 0);
   --color-gray-200: oklch(0.9300 0 0);
   --color-gray-300: oklch(0.8800 0 0);
@@ -26,39 +27,40 @@
   --color-gray-700: oklch(0.4168 0 0);
   --color-gray-800: oklch(0.3118 0 0);
   --color-gray-900: oklch(0.2068 0 0);
+  --color-gray-950: oklch(0.1500 0 0);
 
   /* Blue */
-  --color-blue-100: oklch(0.9700 0.0244 258.52);
-  --color-blue-200: oklch(0.9300 0.0345 258.52);
+  --color-blue-100: oklch(0.9700 0.0144 258.52);
+  --color-blue-200: oklch(0.9300 0.0339 258.52);
   --color-blue-300: oklch(0.8800 0.0447 258.52);
   --color-blue-400: oklch(0.8200 0.0548 258.52);
   --color-blue-500: oklch(0.6923 0.1625 258.52);
   --color-blue-600: oklch(0.5873 0.1740 258.52);
-  --color-blue-700: oklch(0.4823 0.1788 258.52);
-  --color-blue-800: oklch(0.3773 0.1740 258.52);
-  --color-blue-900: oklch(0.2723 0.1625 258.52);
+  --color-blue-700: oklch(0.4823 0.1471 258.52);
+  --color-blue-800: oklch(0.3773 0.1471 258.52);
+  --color-blue-900: oklch(0.2723 0.1113 258.52);
 
   /* Red */
-  --color-red-100: oklch(0.9700 0.0314 24.81);
-  --color-red-200: oklch(0.9300 0.0445 24.81);
+  --color-red-100: oklch(0.9700 0.0148 24.81);
+  --color-red-200: oklch(0.9300 0.0356 24.81);
   --color-red-300: oklch(0.8800 0.0576 24.81);
   --color-red-400: oklch(0.8200 0.0707 24.81);
   --color-red-500: oklch(0.6703 0.2096 24.81);
   --color-red-600: oklch(0.5653 0.2244 24.81);
-  --color-red-700: oklch(0.4603 0.2306 24.81);
-  --color-red-800: oklch(0.3553 0.2244 24.81);
-  --color-red-900: oklch(0.2503 0.2096 24.81);
+  --color-red-700: oklch(0.4603 0.1881 24.81);
+  --color-red-800: oklch(0.3553 0.1467 24.81);
+  --color-red-900: oklch(0.2503 0.1069 24.81);
 
   /* Orange */
-  --color-orange-100: oklch(0.9700 0.0231 60.69);
+  --color-orange-100: oklch(0.9700 0.0189 60.69);
   --color-orange-200: oklch(0.9300 0.0327 60.69);
   --color-orange-300: oklch(0.8800 0.0424 60.69);
   --color-orange-400: oklch(0.8200 0.0520 60.69);
   --color-orange-500: oklch(0.7851 0.1540 60.69);
-  --color-orange-600: oklch(0.6801 0.1649 60.69);
-  --color-orange-700: oklch(0.5751 0.1694 60.69);
-  --color-orange-800: oklch(0.4701 0.1649 60.69);
-  --color-orange-900: oklch(0.3651 0.1540 60.69);
+  --color-orange-600: oklch(0.6801 0.1592 60.69);
+  --color-orange-700: oklch(0.5751 0.1350 60.69);
+  --color-orange-800: oklch(0.4701 0.1110 60.69);
+  --color-orange-900: oklch(0.3651 0.0876 60.69);
 
   /* Green */
   --color-green-100: oklch(0.9700 0.0282 148.95);
@@ -66,10 +68,10 @@
   --color-green-300: oklch(0.8800 0.0516 148.95);
   --color-green-400: oklch(0.8200 0.0634 148.95);
   --color-green-500: oklch(0.7827 0.1878 148.95);
-  --color-green-600: oklch(0.6777 0.2011 148.95);
-  --color-green-700: oklch(0.5727 0.2066 148.95);
-  --color-green-800: oklch(0.4677 0.2011 148.95);
-  --color-green-900: oklch(0.3627 0.1878 148.95);
+  --color-green-600: oklch(0.6777 0.1921 148.95);
+  --color-green-700: oklch(0.5727 0.1627 148.95);
+  --color-green-800: oklch(0.4677 0.1335 148.95);
+  --color-green-900: oklch(0.3627 0.1048 148.95);
 
   /* Typography - Size + Line Height */
   --text-xs: 0.75rem;
@@ -99,9 +101,57 @@
   --tracking-tight: -0.025em;
   --tracking-normal: 0em;
   --tracking-wide: 0.025em;
+}
 
-  /* Shadows */
+/* Semantic color bindings that swap on color scheme */
+@theme inline {
+  --color-canvas: var(--canvas);
+  --color-surface: var(--surface);
+  --color-surface-hover: var(--surface-hover);
+  --color-border-default: var(--border-default);
+  --color-input: var(--input);
+  --color-input-focus: var(--input-focus);
+  --color-fg: var(--fg);
+  --color-fg-muted: var(--fg-muted);
+  --color-fg-subtle: var(--fg-subtle);
+
+  --shadow-card: var(--shadow-card);
+  --shadow-dropdown: var(--shadow-dropdown);
+  --shadow-modal: var(--shadow-modal);
+}
+
+/* Light mode values */
+:root {
+  --canvas: var(--color-white);
+  --surface: var(--color-white);
+  --surface-hover: var(--color-gray-100);
+  --border-default: var(--color-gray-200);
+  --input: var(--color-gray-100);
+  --input-focus: var(--color-gray-200);
+  --fg: var(--color-gray-900);
+  --fg-muted: var(--color-gray-500);
+  --fg-subtle: var(--color-gray-400);
+
   --shadow-card: 0 1px 3px oklch(0 0 0 / 0.08);
   --shadow-dropdown: 0 4px 12px oklch(0 0 0 / 0.12);
   --shadow-modal: 0 8px 30px oklch(0 0 0 / 0.16);
+}
+
+/* Dark mode values */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --canvas: var(--color-gray-950);
+    --surface: var(--color-gray-900);
+    --surface-hover: var(--color-gray-800);
+    --border-default: var(--color-gray-800);
+    --input: var(--color-gray-800);
+    --input-focus: var(--color-gray-700);
+    --fg: var(--color-gray-100);
+    --fg-muted: var(--color-gray-400);
+    --fg-subtle: var(--color-gray-500);
+
+    --shadow-card: 0 1px 3px oklch(0 0 0 / 0.3);
+    --shadow-dropdown: 0 4px 12px oklch(0 0 0 / 0.4);
+    --shadow-modal: 0 8px 30px oklch(0 0 0 / 0.5);
+  }
 }


### PR DESCRIPTION
## 연관 Issue
- closes #14

## 요약
전체 컴포넌트 디자인을 정제하고 다크모드를 추가합니다. `@theme inline`으로 시맨틱 토큰을 정의하여 `prefers-color-scheme`에 따라 자동 전환됩니다.

## 변경 사항
### 디자인 토큰
- sRGB-safe oklch 컬러 복원 (chroma gamut 클램핑)
- 시맨틱 토큰: `canvas`, `surface`, `surface-hover`, `border-default`, `input`, `input-focus`, `fg`, `fg-muted`, `fg-subtle`
- 다크모드 자동 전환 (`@media (prefers-color-scheme: dark)`)

### 컴포넌트 개선
- Input/Textarea: 회색 배경 + 포커스 ring만 (보더 제거)
- Button: rounded-xl 통일, 사이즈별 일관성
- Badge: 6색 variant 다크모드 대응 (bg-800, text-100)
- Avatar: 드래그 방지 (select-none, draggable=false)
- Modal: 중앙 정렬 (m-auto)
- Dropdown: button 중첩 제거 (span + role=button), 좌측 정렬
- Tabs: 비활성 텍스트 fg-muted

### 페이지 전면 리팩토링
- 모든 `text-gray-*`, `bg-gray-*`, `border-gray-*`를 시맨틱 유틸리티로 치환
- 인증/메인/관리자/에러/404/로딩 페이지 전체 다크모드 대응

### 기타
- 신한Q&A 공식 로고 컴포넌트 + 브랜딩 통일
- Lucide 아이콘 적용

## 범위
### 포함:
- 전체 UI 시맨틱 토큰화
- 라이트/다크 모드 자동 전환

### 제외:
- 기능 변경
- 플레이그라운드 페이지 (개발용)