### PR TITLE
[Feat/#17] 비로그인 랜딩 페이지

### DIFF
--- a/apps/home/app/(main)/_components/feed.tsx
+++ b/apps/home/app/(main)/_components/feed.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import type { BoardType } from "@shinhanqna/types";
+import { usePosts } from "@shinhanqna/api";
+import { PostCard, BoardTabBar, Pagination, EmptyState, Spinner } from "@shinhanqna/ui";
+
+export function Feed() {
+  const router = useRouter();
+  const [boardType, setBoardType] = useState<BoardType | undefined>(undefined);
+  const [page, setPage] = useState(0);
+
+  const { data, isLoading } = usePosts(boardType, page);
+
+  return (
+    <div className="flex flex-col">
+      <BoardTabBar activeBoard={boardType} onChange={(bt) => { setBoardType(bt); setPage(0); }} />
+
+      {isLoading ? (
+        <div className="flex justify-center py-16">
+          <Spinner size="lg" />
+        </div>
+      ) : !data || data.items.length === 0 ? (
+        <EmptyState message="게시글이 없습니다" description="첫 번째 글을 작성해보세요" />
+      ) : (
+        <>
+          {data.items.map((post) => (
+            <PostCard
+              key={post.postId}
+              title={post.title}
+              content={post.content}
+              authorName={post.authorName}
+              boardType={post.boardType}
+              likeCount={post.likeCount}
+              commentCount={post.commentCount}
+              createdAt={post.createdAt}
+              onClick={() => router.push(`/post/${post.postId}`)}
+            />
+          ))}
+          <Pagination
+            page={data.page}
+            totalPages={data.totalPages}
+            hasNext={data.hasNext}
+            hasPrevious={data.hasPrevious}
+            onPageChange={setPage}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/home/app/(main)/_components/landing.tsx
+++ b/apps/home/app/(main)/_components/landing.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { Logo, Button } from "@shinhanqna/ui";
+
+export function Landing() {
+  return (
+    <div className="flex min-h-[calc(100vh-3.5rem)] flex-col items-center justify-center px-6 py-12 text-center">
+      <Logo size={64} className="text-cyan-500 mb-6" />
+      <h1 className="text-3xl font-bold tracking-tight text-fg mb-3">
+        신한Q&A에 오신 것을 환영합니다
+      </h1>
+      <p className="text-md text-fg-muted max-w-sm mb-8">
+        신한대학교 캠퍼스 커뮤니티에서 궁금한 것을 묻고, 함께할 팀원을 찾아보세요.
+      </p>
+      <div className="flex flex-col gap-2.5 w-full max-w-xs">
+        <Link href="/login" className="w-full">
+          <Button className="w-full" size="lg">로그인</Button>
+        </Link>
+        <Link href="/register" className="w-full">
+          <Button className="w-full" size="lg" variant="secondary">회원가입</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/home/app/(main)/_components/main-layout-shell.tsx
+++ b/apps/home/app/(main)/_components/main-layout-shell.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import { Home, MessageCircle, Users, BookOpen, User, Plus } from "lucide-react";
+import { ThreeColumnLayout, Sidebar, Header, MobileNav, Logo, Button, type SidebarLink, type MobileNavItem } from "@shinhanqna/ui";
+
+const publicSidebarLinks: SidebarLink[] = [
+  { key: "/", label: "홈", href: "/", icon: <Home className="h-5 w-5" /> },
+  { key: "/board/free", label: "자유게시판", href: "/board/free", icon: <MessageCircle className="h-5 w-5" /> },
+  { key: "/board/qna", label: "Q&A", href: "/board/qna", icon: <BookOpen className="h-5 w-5" /> },
+  { key: "/board/project-recruit", label: "프로젝트 모집", href: "/board/project-recruit", icon: <Users className="h-5 w-5" /> },
+  { key: "/board/study-recruit", label: "스터디 모집", href: "/board/study-recruit", icon: <Users className="h-5 w-5" /> },
+];
+
+const authedSidebarLink: SidebarLink = {
+  key: "/profile", label: "프로필", href: "/profile", icon: <User className="h-5 w-5" />,
+};
+
+const publicMobileNavItems: MobileNavItem[] = [
+  { key: "/", label: "홈", href: "/", icon: <Home className="h-5 w-5" /> },
+  { key: "/board/qna", label: "Q&A", href: "/board/qna", icon: <BookOpen className="h-5 w-5" /> },
+  { key: "/board/project-recruit", label: "모집", href: "/board/project-recruit", icon: <Users className="h-5 w-5" /> },
+];
+
+const authedMobileNavItem: MobileNavItem = {
+  key: "/profile", label: "프로필", href: "/profile", icon: <User className="h-5 w-5" />,
+};
+
+interface MainLayoutShellProps {
+  children: React.ReactNode;
+  isAuthenticated: boolean;
+}
+
+export function MainLayoutShell({ children, isAuthenticated }: MainLayoutShellProps) {
+  const pathname = usePathname();
+
+  const sidebarLinks = isAuthenticated ? [...publicSidebarLinks, authedSidebarLink] : publicSidebarLinks;
+  const mobileNavItems = isAuthenticated ? [...publicMobileNavItems, authedMobileNavItem] : publicMobileNavItems;
+
+  const activeKey = sidebarLinks.find((link) =>
+    link.key === "/" ? pathname === "/" : pathname.startsWith(link.key),
+  )?.key || "/";
+
+  return (
+    <>
+      <ThreeColumnLayout
+        left={
+          <Sidebar
+            links={sidebarLinks}
+            activeKey={activeKey}
+            header={
+              <Link href="/" className="flex items-center gap-2">
+                <Logo size={28} className="text-cyan-500" />
+                <span className="text-lg font-bold text-fg">신한Q&A</span>
+              </Link>
+            }
+          />
+        }
+        center={
+          <div className="flex flex-col">
+            <Header
+              title="신한Q&A"
+              right={
+                isAuthenticated ? (
+                  <Link
+                    href="/post/new"
+                    className="flex items-center gap-1.5 rounded-full bg-cyan-500 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-600 transition-colors"
+                  >
+                    <Plus className="h-4 w-4" />
+                    글쓰기
+                  </Link>
+                ) : (
+                  <Link href="/login">
+                    <Button size="sm">로그인</Button>
+                  </Link>
+                )
+              }
+            />
+            {children}
+          </div>
+        }
+      />
+      <MobileNav items={mobileNavItems} activeKey={activeKey} />
+    </>
+  );
+}

--- a/apps/home/app/(main)/layout.tsx
+++ b/apps/home/app/(main)/layout.tsx
@@ -1,67 +1,13 @@
-"use client";
+import { getAccessToken } from "@/lib/auth-cookies";
+import { MainLayoutShell } from "./_components/main-layout-shell";
 
-import { usePathname } from "next/navigation";
-import { Home, MessageCircle, Users, BookOpen, User, Plus } from "lucide-react";
-import Link from "next/link";
-import { ThreeColumnLayout, Sidebar, Header, MobileNav, Logo, type SidebarLink, type MobileNavItem } from "@shinhanqna/ui";
-
-const sidebarLinks: SidebarLink[] = [
-  { key: "/", label: "홈", href: "/", icon: <Home className="h-5 w-5" /> },
-  { key: "/board/free", label: "자유게시판", href: "/board/free", icon: <MessageCircle className="h-5 w-5" /> },
-  { key: "/board/qna", label: "Q&A", href: "/board/qna", icon: <BookOpen className="h-5 w-5" /> },
-  { key: "/board/project-recruit", label: "프로젝트 모집", href: "/board/project-recruit", icon: <Users className="h-5 w-5" /> },
-  { key: "/board/study-recruit", label: "스터디 모집", href: "/board/study-recruit", icon: <Users className="h-5 w-5" /> },
-  { key: "/profile", label: "프로필", href: "/profile", icon: <User className="h-5 w-5" /> },
-];
-
-const mobileNavItems: MobileNavItem[] = [
-  { key: "/", label: "홈", href: "/", icon: <Home className="h-5 w-5" /> },
-  { key: "/board/qna", label: "Q&A", href: "/board/qna", icon: <BookOpen className="h-5 w-5" /> },
-  { key: "/board/project-recruit", label: "모집", href: "/board/project-recruit", icon: <Users className="h-5 w-5" /> },
-  { key: "/profile", label: "프로필", href: "/profile", icon: <User className="h-5 w-5" /> },
-];
-
-export default function MainLayout({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
-
-  const activeKey = sidebarLinks.find((link) =>
-    link.key === "/" ? pathname === "/" : pathname.startsWith(link.key),
-  )?.key || "/";
+export default async function MainLayout({ children }: { children: React.ReactNode }) {
+  const accessToken = await getAccessToken();
+  const isAuthenticated = !!accessToken;
 
   return (
-    <>
-      <ThreeColumnLayout
-        left={
-          <Sidebar
-            links={sidebarLinks}
-            activeKey={activeKey}
-            header={
-              <Link href="/" className="flex items-center gap-2">
-                <Logo size={28} className="text-cyan-500" />
-                <span className="text-lg font-bold text-fg">신한Q&A</span>
-              </Link>
-            }
-          />
-        }
-        center={
-          <div className="flex flex-col">
-            <Header
-              title="신한Q&A"
-              right={
-                <Link
-                  href="/post/new"
-                  className="flex items-center gap-1.5 rounded-full bg-cyan-500 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-600 transition-colors"
-                >
-                  <Plus className="h-4 w-4" />
-                  글쓰기
-                </Link>
-              }
-            />
-            {children}
-          </div>
-        }
-      />
-      <MobileNav items={mobileNavItems} activeKey={activeKey} />
-    </>
+    <MainLayoutShell isAuthenticated={isAuthenticated}>
+      {children}
+    </MainLayoutShell>
   );
 }

--- a/apps/home/app/(main)/page.tsx
+++ b/apps/home/app/(main)/page.tsx
@@ -1,52 +1,13 @@
-"use client";
+import { getAccessToken } from "@/lib/auth-cookies";
+import { Feed } from "./_components/feed";
+import { Landing } from "./_components/landing";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import type { BoardType } from "@shinhanqna/types";
-import { usePosts } from "@shinhanqna/api";
-import { PostCard, BoardTabBar, Pagination, EmptyState, Spinner } from "@shinhanqna/ui";
+export default async function HomePage() {
+  const accessToken = await getAccessToken();
 
-export default function HomePage() {
-  const router = useRouter();
-  const [boardType, setBoardType] = useState<BoardType | undefined>(undefined);
-  const [page, setPage] = useState(0);
+  if (!accessToken) {
+    return <Landing />;
+  }
 
-  const { data, isLoading } = usePosts(boardType, page);
-
-  return (
-    <div className="flex flex-col">
-      <BoardTabBar activeBoard={boardType} onChange={(bt) => { setBoardType(bt); setPage(0); }} />
-
-      {isLoading ? (
-        <div className="flex justify-center py-16">
-          <Spinner size="lg" />
-        </div>
-      ) : !data || data.items.length === 0 ? (
-        <EmptyState message="게시글이 없습니다" description="첫 번째 글을 작성해보세요" />
-      ) : (
-        <>
-          {data.items.map((post) => (
-            <PostCard
-              key={post.postId}
-              title={post.title}
-              content={post.content}
-              authorName={post.authorName}
-              boardType={post.boardType}
-              likeCount={post.likeCount}
-              commentCount={post.commentCount}
-              createdAt={post.createdAt}
-              onClick={() => router.push(`/post/${post.postId}`)}
-            />
-          ))}
-          <Pagination
-            page={data.page}
-            totalPages={data.totalPages}
-            hasNext={data.hasNext}
-            hasPrevious={data.hasPrevious}
-            onPageChange={setPage}
-          />
-        </>
-      )}
-    </div>
-  );
+  return <Feed />;
 }

--- a/apps/home/proxy.ts
+++ b/apps/home/proxy.ts
@@ -1,22 +1,31 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-const PUBLIC_PATHS = ["/login", "/register"];
+/** 누구나 접근 가능 (로그인 여부 무관) */
+const PUBLIC_PATHS = ["/"];
+
+/** 비로그인만 접근 가능 (로그인 상태면 홈으로 리다이렉트) */
+const GUEST_ONLY_PATHS = ["/login", "/register"];
+
+function matches(pathname: string, paths: string[]) {
+  return paths.some((path) => pathname === path || pathname.startsWith(path + "/"));
+}
 
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const accessToken = request.cookies.get("access_token")?.value;
 
-  const isPublicPath = PUBLIC_PATHS.some((path) => pathname === path || pathname.startsWith(path + "/"));
+  const isPublic = matches(pathname, PUBLIC_PATHS);
+  const isGuestOnly = matches(pathname, GUEST_ONLY_PATHS);
 
-  if (!accessToken && !isPublicPath) {
+  if (accessToken && isGuestOnly) {
+    return NextResponse.redirect(new URL("/", request.url));
+  }
+
+  if (!accessToken && !isPublic && !isGuestOnly) {
     const loginUrl = new URL("/login", request.url);
     loginUrl.searchParams.set("from", pathname);
     return NextResponse.redirect(loginUrl);
-  }
-
-  if (accessToken && isPublicPath) {
-    return NextResponse.redirect(new URL("/", request.url));
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## 연관 Issue
- closes #17

## 요약
비로그인 상태에서도 `/`에 접근 가능하도록 하고, 로그인/회원가입 유도 랜딩 화면을 구성했습니다. 로그인 상태에서는 기존 피드를 그대로 표시합니다.

## 변경 사항
- `proxy.ts` public/guest-only 경로 분리, `/`를 공개로 허용
- `(main)/_components/feed.tsx` 클라이언트 피드 컴포넌트로 분리
- `(main)/_components/landing.tsx` 비로그인 랜딩 CTA 구현
- `(main)/page.tsx` 서버 컴포넌트로 전환 — 쿠키 기반 랜딩/피드 분기
- `(main)/_components/main-layout-shell.tsx` 인증 상태별 네비게이션 (글쓰기/프로필 링크 토글)
- `(main)/layout.tsx` 서버 컴포넌트로 전환 — 쿠키로 isAuthenticated 판별

## 범위
### 포함:
- `/`, `/login`, `/register` 공개(또는 비로그인 전용) 허용
- 비로그인 랜딩: 로고 + 타이틀 + 소개 + 로그인/회원가입 버튼
- 인증 상태별 사이드바/헤더/모바일 네비 토글

### 제외:
- 비로그인 상태에서 게시글 목록 노출
- 다른 라우트의 공개 접근 정책 변경