### PR TITLE
[Design/#21] 홈 피드 단순화 및 네비게이션 제거

### DIFF
--- a/apps/home/app/(main)/_components/feed.tsx
+++ b/apps/home/app/(main)/_components/feed.tsx
@@ -8,7 +8,7 @@ import { PostCard, BoardTabBar, Pagination, EmptyState, Spinner } from "@shinhan
 
 export function Feed() {
   const router = useRouter();
-  const [boardType, setBoardType] = useState<BoardType | undefined>(undefined);
+  const [boardType, setBoardType] = useState<BoardType>("FREE");
   const [page, setPage] = useState(0);
 
   const { data, isLoading } = usePosts(boardType, page);

--- a/apps/home/app/(main)/_components/main-layout-shell.tsx
+++ b/apps/home/app/(main)/_components/main-layout-shell.tsx
@@ -27,7 +27,7 @@ export function MainLayoutShell({ children, isAuthenticated }: MainLayoutShellPr
   };
 
   return (
-    <div className="mx-auto flex min-h-screen w-full max-w-[640px] flex-col border-x border-border-default">
+    <div className="mx-auto flex min-h-screen w-full max-w-[640px] lg:max-w-3xl xl:max-w-4xl flex-col border-x border-border-default">
       <Header
         left={
           <Link href="/" className="flex items-center gap-2">

--- a/apps/home/app/(main)/_components/main-layout-shell.tsx
+++ b/apps/home/app/(main)/_components/main-layout-shell.tsx
@@ -1,31 +1,9 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { Home, MessageCircle, Users, BookOpen, User, Plus } from "lucide-react";
-import { ThreeColumnLayout, Sidebar, Header, MobileNav, Logo, Button, type SidebarLink, type MobileNavItem } from "@shinhanqna/ui";
-
-const publicSidebarLinks: SidebarLink[] = [
-  { key: "/", label: "홈", href: "/", icon: <Home className="h-5 w-5" /> },
-  { key: "/board/free", label: "자유게시판", href: "/board/free", icon: <MessageCircle className="h-5 w-5" /> },
-  { key: "/board/qna", label: "Q&A", href: "/board/qna", icon: <BookOpen className="h-5 w-5" /> },
-  { key: "/board/project-recruit", label: "프로젝트 모집", href: "/board/project-recruit", icon: <Users className="h-5 w-5" /> },
-  { key: "/board/study-recruit", label: "스터디 모집", href: "/board/study-recruit", icon: <Users className="h-5 w-5" /> },
-];
-
-const authedSidebarLink: SidebarLink = {
-  key: "/profile", label: "프로필", href: "/profile", icon: <User className="h-5 w-5" />,
-};
-
-const publicMobileNavItems: MobileNavItem[] = [
-  { key: "/", label: "홈", href: "/", icon: <Home className="h-5 w-5" /> },
-  { key: "/board/qna", label: "Q&A", href: "/board/qna", icon: <BookOpen className="h-5 w-5" /> },
-  { key: "/board/project-recruit", label: "모집", href: "/board/project-recruit", icon: <Users className="h-5 w-5" /> },
-];
-
-const authedMobileNavItem: MobileNavItem = {
-  key: "/profile", label: "프로필", href: "/profile", icon: <User className="h-5 w-5" />,
-};
+import { User, Plus } from "lucide-react";
+import { Header, Logo, Button, Dropdown } from "@shinhanqna/ui";
 
 interface MainLayoutShellProps {
   children: React.ReactNode;
@@ -33,55 +11,61 @@ interface MainLayoutShellProps {
 }
 
 export function MainLayoutShell({ children, isAuthenticated }: MainLayoutShellProps) {
-  const pathname = usePathname();
+  const router = useRouter();
 
-  const sidebarLinks = isAuthenticated ? [...publicSidebarLinks, authedSidebarLink] : publicSidebarLinks;
-  const mobileNavItems = isAuthenticated ? [...publicMobileNavItems, authedMobileNavItem] : publicMobileNavItems;
+  async function handleLogout() {
+    try {
+      await fetch("/api/auth/logout", { method: "POST" });
+    } finally {
+      window.location.href = "/";
+    }
+  }
 
-  const activeKey = sidebarLinks.find((link) =>
-    link.key === "/" ? pathname === "/" : pathname.startsWith(link.key),
-  )?.key || "/";
+  const handleProfileSelect = (key: string) => {
+    if (key === "profile") router.push("/profile");
+    else if (key === "logout") void handleLogout();
+  };
 
   return (
-    <>
-      <ThreeColumnLayout
+    <div className="mx-auto flex min-h-screen w-full max-w-[640px] flex-col border-x border-border-default">
+      <Header
         left={
-          <Sidebar
-            links={sidebarLinks}
-            activeKey={activeKey}
-            header={
-              <Link href="/" className="flex items-center gap-2">
-                <Logo size={28} className="text-cyan-500" />
-                <span className="text-lg font-bold text-fg">신한Q&A</span>
-              </Link>
-            }
-          />
+          <Link href="/" className="flex items-center gap-2">
+            <Logo size={28} className="text-cyan-500" />
+            <span className="text-lg font-bold text-fg">신한Q&A</span>
+          </Link>
         }
-        center={
-          <div className="flex flex-col">
-            <Header
-              title="신한Q&A"
-              right={
-                isAuthenticated ? (
-                  <Link
-                    href="/post/new"
-                    className="flex items-center gap-1.5 rounded-full bg-cyan-500 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-600 transition-colors"
-                  >
-                    <Plus className="h-4 w-4" />
-                    글쓰기
-                  </Link>
-                ) : (
-                  <Link href="/login">
-                    <Button size="sm">로그인</Button>
-                  </Link>
-                )
-              }
-            />
-            {children}
-          </div>
+        right={
+          isAuthenticated ? (
+            <div className="flex items-center gap-2">
+              <Link
+                href="/post/new"
+                className="flex items-center gap-1.5 rounded-full bg-cyan-500 px-4 py-2 text-sm font-medium text-white hover:bg-cyan-600 transition-colors"
+              >
+                <Plus className="h-4 w-4" />
+                글쓰기
+              </Link>
+              <Dropdown
+                trigger={
+                  <span className="flex h-9 w-9 items-center justify-center rounded-full border border-border-default bg-surface text-fg hover:bg-surface-hover transition-colors">
+                    <User className="h-5 w-5" />
+                  </span>
+                }
+                items={[
+                  { key: "profile", label: "프로필" },
+                  { key: "logout", label: "로그아웃", danger: true },
+                ]}
+                onSelect={handleProfileSelect}
+              />
+            </div>
+          ) : (
+            <Link href="/login">
+              <Button size="sm">로그인</Button>
+            </Link>
+          )
         }
       />
-      <MobileNav items={mobileNavItems} activeKey={activeKey} />
-    </>
+      {children}
+    </div>
   );
 }

--- a/packages/ui/src/composites/board-tab-bar.tsx
+++ b/packages/ui/src/composites/board-tab-bar.tsx
@@ -4,13 +4,12 @@ import type { BoardType } from "@shinhanqna/types";
 import { Tabs, type TabItem } from "../primitives/tabs";
 
 interface BoardTabBarProps {
-  activeBoard?: BoardType;
-  onChange: (boardType?: BoardType) => void;
+  activeBoard: BoardType;
+  onChange: (boardType: BoardType) => void;
   className?: string;
 }
 
 const boardTabs: TabItem[] = [
-  { key: "ALL", label: "전체" },
   { key: "FREE", label: "자유" },
   { key: "QNA", label: "Q&A" },
   { key: "PROJECT_RECRUIT", label: "프로젝트 모집" },
@@ -21,8 +20,8 @@ function BoardTabBar({ activeBoard, onChange, className }: BoardTabBarProps) {
   return (
     <Tabs
       items={boardTabs}
-      activeKey={activeBoard || "ALL"}
-      onChange={(key) => onChange(key === "ALL" ? undefined : (key as BoardType))}
+      activeKey={activeBoard}
+      onChange={(key) => onChange(key as BoardType)}
       className={className}
     />
   );

--- a/packages/ui/src/layouts/header.tsx
+++ b/packages/ui/src/layouts/header.tsx
@@ -2,7 +2,7 @@ import { type ReactNode } from "react";
 import { cn } from "../lib/cn";
 
 interface HeaderProps {
-  title: string;
+  title?: string;
   left?: ReactNode;
   right?: ReactNode;
   className?: string;
@@ -18,7 +18,7 @@ function Header({ title, left, right, className }: HeaderProps) {
     >
       <div className="flex items-center gap-3">
         {left}
-        <h1 className="text-lg font-bold text-fg">{title}</h1>
+        {title && <h1 className="text-lg font-bold text-fg">{title}</h1>}
       </div>
       {right && <div className="flex items-center gap-2">{right}</div>}
     </header>


### PR DESCRIPTION
## 연관 Issue
- closes #21

## 요약
`GET /api/v1/posts`의 `boardType`이 필수 파라미터이므로 "전체" 통합 피드 개념을 포기하고 홈 피드 진입 시 FREE(자유게시판)로 고정했습니다. 좌측 Sidebar와 모바일 MobileNav를 제거해 단일 컬럼 레이아웃으로 단순화하고, 프로필 진입 경로는 헤더 드롭다운으로 일원화했습니다. 게시판 전환은 BoardTabBar로 계속 가능합니다.

## 변경 사항
- `BoardTabBar`에서 "전체" 탭 제거, `onChange` 시그니처를 `(bt: BoardType) => void`로 tightening
- `Feed`의 초기 boardType을 `"FREE"`로 고정
- `Header`의 `title` prop을 optional로 변경 (left에 로고·텍스트 링크만 배치하는 경우 허용)
- `MainLayoutShell` 재구성
  - `ThreeColumnLayout` · `Sidebar` · `MobileNav` 제거
  - 중앙 단일 컬럼(`mx-auto max-w-[640px] lg:max-w-3xl xl:max-w-4xl border-x`)
  - 헤더 좌측: 로고 + "신한Q&A" 링크
  - 헤더 우측(로그인 시): 글쓰기 + 프로필 드롭다운 (프로필 이동 / 로그아웃)
  - 헤더 우측(비로그인): 로그인 버튼
  - 로그아웃은 `/api/auth/logout` 호출 후 `/`로 하드 리로드

## 범위
### 포함:
- Feed 초기 boardType "FREE" 고정
- BoardTabBar "전체" 탭 삭제
- 좌측 Sidebar, 모바일 하단 MobileNav 제거
- Header에 프로필 드롭다운 통합
- 단일 컬럼 반응형 최대 너비 (PC에서 확장)

### 제외:
- `/board/[boardType]` 상세 페이지 구조 (URL 직접 접근 유지)
- 게시글 상세/작성 화면은 변경하지 않음