### PR TITLE
[Design/#23] 관리자 앱 반응형 대응

### DIFF
--- a/apps/admin/app/(dashboard)/layout.tsx
+++ b/apps/admin/app/(dashboard)/layout.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { LayoutDashboard, FileWarning, MessageSquareWarning, LogOut } from "lucide-react";
 import Link from "next/link";
+import { LayoutDashboard, FileWarning, MessageSquareWarning, LogOut, Menu } from "lucide-react";
 import { Sidebar, Logo, Button, type SidebarLink } from "@shinhanqna/ui";
 import { useLogout } from "@shinhanqna/api";
 
@@ -16,6 +17,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
   const pathname = usePathname();
   const router = useRouter();
   const logoutMutation = useLogout();
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const activeKey = sidebarLinks.find((link) =>
     link.key === "/" ? pathname === "/" : pathname.startsWith(link.key),
@@ -31,27 +33,76 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
     );
   };
 
+  useEffect(() => {
+    setDrawerOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setDrawerOpen(false);
+    };
+    document.addEventListener("keydown", handler);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handler);
+      document.body.style.overflow = "";
+    };
+  }, [drawerOpen]);
+
+  const sidebar = (
+    <Sidebar
+      links={sidebarLinks}
+      activeKey={activeKey}
+      header={
+        <Link href="/" className="flex items-center gap-2">
+          <Logo size={28} className="text-cyan-500" />
+          <span className="text-lg font-bold text-fg">관리자</span>
+        </Link>
+      }
+      footer={
+        <Button variant="ghost" onClick={handleLogout} className="w-full text-fg-muted justify-start">
+          <LogOut className="h-4 w-4 mr-2" />
+          로그아웃
+        </Button>
+      }
+    />
+  );
+
   return (
     <div className="flex min-h-screen">
-      <Sidebar
-        links={sidebarLinks}
-        activeKey={activeKey}
-        header={
+      <div className="hidden lg:flex">{sidebar}</div>
+
+      <div className="flex flex-1 flex-col min-w-0">
+        <header className="lg:hidden sticky top-0 z-30 flex items-center justify-between h-14 px-4 border-b border-border-default bg-surface/80 backdrop-blur-sm">
+          <button
+            type="button"
+            onClick={() => setDrawerOpen(true)}
+            aria-label="메뉴 열기"
+            className="-ml-2 flex h-9 w-9 items-center justify-center rounded-lg text-fg hover:bg-surface-hover transition-colors"
+          >
+            <Menu className="h-5 w-5" />
+          </button>
           <Link href="/" className="flex items-center gap-2">
-            <Logo size={28} className="text-cyan-500" />
-            <span className="text-lg font-bold text-fg">관리자</span>
+            <Logo size={24} className="text-cyan-500" />
+            <span className="text-base font-bold text-fg">관리자</span>
           </Link>
-        }
-        footer={
-          <Button variant="ghost" onClick={handleLogout} className="w-full text-fg-muted justify-start">
-            <LogOut className="h-4 w-4 mr-2" />
-            로그아웃
-          </Button>
-        }
-      />
-      <main className="flex-1 bg-surface-hover">
-        {children}
-      </main>
+          <span className="w-9" aria-hidden="true" />
+        </header>
+
+        <main className="flex-1 bg-surface-hover">{children}</main>
+      </div>
+
+      {drawerOpen && (
+        <div className="fixed inset-0 z-50 lg:hidden" role="dialog" aria-modal="true">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setDrawerOpen(false)}
+            aria-hidden="true"
+          />
+          <div className="relative h-full w-[280px] bg-surface shadow-modal">{sidebar}</div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/admin/app/(dashboard)/page.tsx
+++ b/apps/admin/app/(dashboard)/page.tsx
@@ -11,8 +11,8 @@ export default function DashboardPage() {
   const isLoading = postsLoading || commentsLoading;
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold text-fg mb-6">대시보드</h1>
+    <div className="p-4 sm:p-6">
+      <h1 className="text-xl sm:text-2xl font-bold text-fg mb-4 sm:mb-6">대시보드</h1>
 
       {isLoading ? (
         <div className="flex justify-center py-16"><Spinner size="lg" /></div>

--- a/apps/admin/app/(dashboard)/reports/comments/page.tsx
+++ b/apps/admin/app/(dashboard)/reports/comments/page.tsx
@@ -27,8 +27,8 @@ export default function CommentReportsPage() {
   };
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold text-fg mb-6">댓글 신고 관리</h1>
+    <div className="p-4 sm:p-6">
+      <h1 className="text-xl sm:text-2xl font-bold text-fg mb-4 sm:mb-6">댓글 신고 관리</h1>
 
       {isLoading ? (
         <div className="flex justify-center py-16"><Spinner size="lg" /></div>
@@ -36,8 +36,8 @@ export default function CommentReportsPage() {
         <EmptyState message="신고된 댓글이 없습니다" />
       ) : (
         <>
-          <div className="rounded-xl bg-surface shadow-card overflow-hidden">
-            <table className="w-full text-sm">
+          <div className="rounded-xl bg-surface shadow-card overflow-x-auto">
+            <table className="w-full min-w-[780px] text-sm">
               <thead className="bg-surface-hover text-fg-muted">
                 <tr>
                   <th className="text-left px-4 py-3 font-medium">댓글 ID</th>

--- a/apps/admin/app/(dashboard)/reports/posts/page.tsx
+++ b/apps/admin/app/(dashboard)/reports/posts/page.tsx
@@ -27,8 +27,8 @@ export default function PostReportsPage() {
   };
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold text-fg mb-6">게시글 신고 관리</h1>
+    <div className="p-4 sm:p-6">
+      <h1 className="text-xl sm:text-2xl font-bold text-fg mb-4 sm:mb-6">게시글 신고 관리</h1>
 
       {isLoading ? (
         <div className="flex justify-center py-16"><Spinner size="lg" /></div>
@@ -36,8 +36,8 @@ export default function PostReportsPage() {
         <EmptyState message="신고된 게시글이 없습니다" />
       ) : (
         <>
-          <div className="rounded-xl bg-surface shadow-card overflow-hidden">
-            <table className="w-full text-sm">
+          <div className="rounded-xl bg-surface shadow-card overflow-x-auto">
+            <table className="w-full min-w-[720px] text-sm">
               <thead className="bg-surface-hover text-fg-muted">
                 <tr>
                   <th className="text-left px-4 py-3 font-medium">게시글 ID</th>


### PR DESCRIPTION
## 연관 Issue
- closes #23

## 요약
관리자 앱(`apps/admin`)이 고정 240px Sidebar + Main 레이아웃이라 좁은 뷰포트에서 화면이 잘리던 문제를 해결했습니다. 모바일·태블릿에서는 Sidebar를 숨기고 상단 Header + 햄버거 드로어로 전환하며, 신고 목록 테이블은 페이지 전체가 밀리지 않도록 테이블 내부에서 가로 스크롤되게 처리했습니다.

## 변경 사항
- `DashboardLayout`
  - Sidebar를 `hidden lg:flex`로 데스크톱 전용 표시
  - 모바일용 `<header>` 추가 (햄버거 + 로고·"관리자" 링크)
  - 햄버거 클릭 시 Sidebar를 드로어(오버레이 + 좌측 280px 패널)로 렌더
  - 배경 클릭·ESC 키로 닫기, 드로어 오픈 시 body scroll lock
  - 라우트 변경 시 자동으로 드로어 닫기
- 관리자 페이지(`dashboard`, `reports/posts`, `reports/comments`)
  - 모바일 여백 축소: `p-6` → `p-4 sm:p-6`
  - 타이틀 크기 반응형: `text-2xl` → `text-xl sm:text-2xl`
  - 신고 테이블: 래퍼를 `overflow-x-auto`로 바꾸고 테이블에 `min-w-[720px]`(게시글) / `min-w-[780px]`(댓글) 지정해 테이블만 가로 스크롤

## 범위
### 포함:
- 데스크톱 Sidebar 유지, 모바일/태블릿 드로어 전환
- 모바일 Header + 햄버거 토글
- 드로어 배경 클릭·ESC 닫기, body scroll lock
- 신고 목록 테이블 가로 스크롤
- 대시보드·신고 페이지 모바일 여백·타이틀 크기 조정

### 제외:
- 관리 기능 로직(신고 처리, 삭제 등)은 변경하지 않음