### PR TITLE
[Fix/#25] 홈/관리자 앱 인증 쿠키 분리

### DIFF
--- a/apps/admin/app/lib/auth-cookies.ts
+++ b/apps/admin/app/lib/auth-cookies.ts
@@ -1,7 +1,7 @@
 import { cookies } from "next/headers";
 
-const ACCESS_TOKEN_KEY = "access_token";
-const REFRESH_TOKEN_KEY = "refresh_token";
+const ACCESS_TOKEN_KEY = "admin_access_token";
+const REFRESH_TOKEN_KEY = "admin_refresh_token";
 
 const COOKIE_OPTIONS = {
   httpOnly: true,

--- a/apps/admin/proxy.ts
+++ b/apps/admin/proxy.ts
@@ -5,7 +5,7 @@ const PUBLIC_PATHS = ["/login"];
 
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
-  const accessToken = request.cookies.get("access_token")?.value;
+  const accessToken = request.cookies.get("admin_access_token")?.value;
 
   const isPublicPath = PUBLIC_PATHS.some((path) => pathname === path || pathname.startsWith(path + "/"));
 

--- a/apps/home/app/lib/auth-cookies.ts
+++ b/apps/home/app/lib/auth-cookies.ts
@@ -1,7 +1,7 @@
 import { cookies } from "next/headers";
 
-const ACCESS_TOKEN_KEY = "access_token";
-const REFRESH_TOKEN_KEY = "refresh_token";
+const ACCESS_TOKEN_KEY = "student_access_token";
+const REFRESH_TOKEN_KEY = "student_refresh_token";
 
 const COOKIE_OPTIONS = {
   httpOnly: true,

--- a/apps/home/proxy.ts
+++ b/apps/home/proxy.ts
@@ -13,7 +13,7 @@ function matches(pathname: string, paths: string[]) {
 
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
-  const accessToken = request.cookies.get("access_token")?.value;
+  const accessToken = request.cookies.get("student_access_token")?.value;
 
   const isPublic = matches(pathname, PUBLIC_PATHS);
   const isGuestOnly = matches(pathname, GUEST_ONLY_PATHS);


### PR DESCRIPTION
## 연관 Issue
- closes #25

## 요약
홈 앱과 관리자 앱이 동일한 쿠키 이름(`access_token`, `refresh_token`)을 사용해 localhost 환경에서 한쪽 로그인이 다른 쪽으로 새는 문제를 해결했습니다. 브라우저가 localhost에서 포트 구분 없이 쿠키를 공유하기 때문에, 두 앱의 BFF 쿠키 이름을 앱별 prefix로 분리했습니다.

## 변경 사항
- 홈 앱 쿠키 이름: `access_token` / `refresh_token` → `student_access_token` / `student_refresh_token`
- 관리자 앱 쿠키 이름: `access_token` / `refresh_token` → `admin_access_token` / `admin_refresh_token`
- 각 앱의 `auth-cookies.ts`와 `proxy.ts` 모두 새 이름으로 일치

## 범위
### 포함:
- `apps/home/app/lib/auth-cookies.ts` 쿠키 키 상수 변경
- `apps/home/proxy.ts` 쿠키 참조 키 변경
- `apps/admin/app/lib/auth-cookies.ts` 쿠키 키 상수 변경
- `apps/admin/proxy.ts` 쿠키 참조 키 변경

### 제외:
- 인증 로직(토큰 발급·만료·refresh 흐름)과 외부 API 스펙은 변경 없음
- 레거시 쿠키 잔존 cleanup은 본 PR에 포함하지 않음 (사용자가 로그아웃 또는 세션 만료 시 자연 소멸)

## 동작 확인
- [x] 홈 앱 로그인 상태에서 관리자 앱(:3001) 접속 시 `/login` 리다이렉트
- [x] 관리자 앱 로그인 상태에서 홈 앱(:3000) 접속 시 비인증 상태(랜딩 표시)
- [x] 각 앱에서 로그인/로그아웃 정상 동작