### PR TITLE
[Design/#27] UI 컴포넌트 다크모드 미대응 수정

### DIFF
--- a/packages/ui/src/layouts/sidebar.tsx
+++ b/packages/ui/src/layouts/sidebar.tsx
@@ -31,7 +31,7 @@ function Sidebar({ links, activeKey, header, footer, className }: SidebarProps) 
             className={cn(
               "flex items-center gap-3 mx-2 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors",
               activeKey === link.key
-                ? "bg-cyan-100 text-cyan-900"
+                ? "bg-cyan-100 text-cyan-900 dark:bg-cyan-900/30 dark:text-cyan-100"
                 : "text-fg-muted hover:bg-surface-hover hover:text-fg",
             )}
           >

--- a/packages/ui/src/primitives/dropdown.tsx
+++ b/packages/ui/src/primitives/dropdown.tsx
@@ -71,7 +71,7 @@ function Dropdown({ trigger, items, onSelect, className }: DropdownProps) {
               className={cn(
                 "w-full px-4 py-2.5 text-left text-sm transition-colors",
                 item.danger
-                  ? "text-red-500 hover:bg-red-100"
+                  ? "text-red-500 hover:bg-red-100 dark:hover:bg-red-900/30"
                   : "text-fg hover:bg-surface-hover",
               )}
             >

--- a/packages/ui/src/primitives/input.tsx
+++ b/packages/ui/src/primitives/input.tsx
@@ -25,7 +25,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           aria-describedby={errorId}
           className={cn(
             "w-full rounded-xl border-none bg-input px-4 py-3 text-base text-fg placeholder:text-fg-subtle transition-all outline-none ring-0 focus:ring-2 focus:ring-cyan-500/30 focus:bg-input-focus",
-            error && "ring-2 ring-red-500/30 bg-red-100/30",
+            error && "ring-2 ring-red-500/30 bg-red-100/30 dark:bg-red-900/30",
             className,
           )}
           {...props}

--- a/packages/ui/src/primitives/textarea.tsx
+++ b/packages/ui/src/primitives/textarea.tsx
@@ -25,7 +25,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           aria-describedby={errorId}
           className={cn(
             "w-full rounded-xl border-none bg-input px-4 py-3 text-base text-fg placeholder:text-fg-subtle transition-all resize-none outline-none ring-0 focus:ring-2 focus:ring-cyan-500/30 focus:bg-input-focus",
-            error && "ring-2 ring-red-500/30 bg-red-100/30",
+            error && "ring-2 ring-red-500/30 bg-red-100/30 dark:bg-red-900/30",
             className,
           )}
           rows={4}


### PR DESCRIPTION
## 연관 Issue
- closes #27

## 요약
`packages/ui/src` 내 4개 컴포넌트에서 라이트 전용 palette 색상이 `dark:` variant 없이 사용되어 다크모드에서 부자연스러운 배경이 노출되던 문제를 수정했습니다.

## 변경 사항
- `primitives/dropdown.tsx` — danger item hover `hover:bg-red-100` → `dark:hover:bg-red-900/30` 추가
- `primitives/input.tsx` — error 상태 `bg-red-100/30` → `dark:bg-red-900/30` 추가
- `primitives/textarea.tsx` — error 상태 `bg-red-100/30` → `dark:bg-red-900/30` 추가
- `layouts/sidebar.tsx` — active 링크 `bg-cyan-100 text-cyan-900` → `dark:bg-cyan-900/30 dark:text-cyan-100` 추가

## 범위
### 포함:
- 위 4개 파일의 `dark:` variant 추가

### 제외:
- `like-button.tsx`, `badge.tsx`, `avatar.tsx`, `report-dialog.tsx`는 이미 `dark:` 대응 완료 확인하여 변경 없음