### PR TITLE
[Fix/#29] 게시글 상세 페이지 레이아웃 버그 수정

### DIFF
--- a/apps/home/app/(main)/post/[postId]/page.tsx
+++ b/apps/home/app/(main)/post/[postId]/page.tsx
@@ -133,7 +133,7 @@ export default function PostDetailPage() {
           <h2 className="text-base font-semibold text-fg">댓글 {post.commentCount}</h2>
         </div>
 
-        <form onSubmit={handleComment} className="flex gap-2 px-4 pb-3">
+        <form onSubmit={handleComment} className="flex flex-col gap-2 px-4 pb-3">
           <Textarea
             placeholder="댓글을 입력하세요"
             value={commentText}

--- a/apps/home/app/(main)/post/[postId]/page.tsx
+++ b/apps/home/app/(main)/post/[postId]/page.tsx
@@ -101,7 +101,7 @@ export default function PostDetailPage() {
         {post.imageUrls.length > 0 && (
           <div className="flex gap-2 overflow-x-auto mb-4">
             {post.imageUrls.map((url, i) => (
-              <img key={i} src={url} alt="" className="rounded-xl max-h-80 object-cover" />
+              <img key={i} src={url} alt="" className="shrink-0 rounded-xl max-h-80 object-cover" />
             ))}
           </div>
         )}


### PR DESCRIPTION
## 연관 Issue
- closes #29

## 요약
게시글 상세 페이지의 CSS 레이아웃 버그 2건을 수정했습니다.

## 변경 사항
- 댓글 작성 폼: `flex` → `flex flex-col` 추가 (textarea와 버튼이 가로로 배치되던 문제)
- 이미지 갤러리: `<img>`에 `shrink-0` 추가 (가로 스크롤 컨테이너에서 이미지가 압축되던 문제)

## 범위
### 포함:
- `apps/home/app/(main)/post/[postId]/page.tsx` 2개 수정 (각 1줄)

### 제외:
- 나머지 flex 컨테이너는 기본 row가 의도된 레이아웃이라 변경 없음