### PR TITLE
[Feat/#32] Access Token 자동 재발급 및 세션 만료 처리 강화

### DIFF
--- a/apps/admin/app/lib/api-proxy.ts
+++ b/apps/admin/app/lib/api-proxy.ts
@@ -3,18 +3,19 @@ import { getAccessToken, getRefreshToken, setAuthCookies, clearAuthCookies } fro
 
 const API_URL = process.env.API_URL;
 
-let refreshPromise: Promise<string | null> | null = null;
+const refreshPromises = new Map<string, Promise<string | null>>();
 
 async function tryRefresh(): Promise<string | null> {
-  if (refreshPromise) return refreshPromise;
+  const refreshToken = await getRefreshToken();
+  if (!refreshToken) {
+    await clearAuthCookies();
+    return null;
+  }
 
-  refreshPromise = (async () => {
-    const refreshToken = await getRefreshToken();
-    if (!refreshToken) {
-      await clearAuthCookies();
-      return null;
-    }
+  const existing = refreshPromises.get(refreshToken);
+  if (existing) return existing;
 
+  const promise = (async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/auth/refresh`, {
         method: "POST",
@@ -35,10 +36,11 @@ async function tryRefresh(): Promise<string | null> {
       return null;
     }
   })().finally(() => {
-    refreshPromise = null;
+    refreshPromises.delete(refreshToken);
   });
 
-  return refreshPromise;
+  refreshPromises.set(refreshToken, promise);
+  return promise;
 }
 
 async function sendWithAuth(path: string, init: RequestInit, overrideToken?: string): Promise<Response> {
@@ -66,6 +68,7 @@ async function buildProxyResponse(res: Response) {
       { status: 401 },
     );
   }
+
   if (res.status === 204 || res.headers.get("content-length") === "0") {
     return NextResponse.json({ resultCode: "200", msg: "success", data: {} }, { status: res.status });
   }

--- a/apps/admin/app/lib/api-proxy.ts
+++ b/apps/admin/app/lib/api-proxy.ts
@@ -1,34 +1,95 @@
 import { NextResponse } from "next/server";
-import { getAccessToken } from "./auth-cookies";
+import { getAccessToken, getRefreshToken, setAuthCookies, clearAuthCookies } from "./auth-cookies";
 
 const API_URL = process.env.API_URL;
+
+let refreshPromise: Promise<boolean> | null = null;
+
+async function tryRefresh(): Promise<boolean> {
+  if (refreshPromise) return refreshPromise;
+
+  refreshPromise = (async () => {
+    const refreshToken = await getRefreshToken();
+    if (!refreshToken) {
+      await clearAuthCookies();
+      return false;
+    }
+
+    try {
+      const res = await fetch(`${API_URL}/api/v1/auth/refresh`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken }),
+      });
+
+      if (!res.ok) {
+        await clearAuthCookies();
+        return false;
+      }
+
+      const data = await res.json();
+      await setAuthCookies(data.data.accessToken, data.data.refreshToken);
+      return true;
+    } catch {
+      await clearAuthCookies();
+      return false;
+    }
+  })().finally(() => {
+    refreshPromise = null;
+  });
+
+  return refreshPromise;
+}
+
+async function sendWithAuth(path: string, init: RequestInit): Promise<Response> {
+  const accessToken = await getAccessToken();
+  const headers = new Headers(init.headers);
+  if (accessToken) headers.set("Authorization", `Bearer ${accessToken}`);
+  return fetch(`${API_URL}${path}`, { ...init, headers });
+}
+
+async function withAutoRefresh(execute: () => Promise<Response>): Promise<Response> {
+  let res = await execute();
+  if (res.status === 401) {
+    const refreshed = await tryRefresh();
+    if (refreshed) res = await execute();
+  }
+  return res;
+}
+
+async function buildProxyResponse(res: Response) {
+  if (res.status === 401) {
+    return NextResponse.json(
+      { resultCode: "401", msg: "세션이 만료되었습니다", data: {} },
+      { status: 401 },
+    );
+  }
+  if (res.status === 204 || res.headers.get("content-length") === "0") {
+    return NextResponse.json({ resultCode: "200", msg: "success", data: {} }, { status: res.status });
+  }
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}
 
 export async function apiProxy(
   path: string,
   options: { method?: string; body?: unknown; contentType?: string } = {},
 ) {
-  const accessToken = await getAccessToken();
   const { method = "GET", body, contentType } = options;
-
   const headers: Record<string, string> = {};
-  if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
   if (contentType) headers["Content-Type"] = contentType;
+  const serializedBody =
+    body !== undefined
+      ? typeof body === "string"
+        ? body
+        : JSON.stringify(body)
+      : undefined;
 
   try {
-    const res = await fetch(`${API_URL}${path}`, {
-      method,
-      headers,
-      body: body !== undefined
-        ? typeof body === "string" ? body : JSON.stringify(body)
-        : undefined,
-    });
-
-    if (res.status === 204 || res.headers.get("content-length") === "0") {
-      return NextResponse.json({ resultCode: "200", msg: "success", data: {} }, { status: res.status });
-    }
-
-    const data = await res.json();
-    return NextResponse.json(data, { status: res.status });
+    const res = await withAutoRefresh(() =>
+      sendWithAuth(path, { method, headers, body: serializedBody }),
+    );
+    return buildProxyResponse(res);
   } catch {
     return NextResponse.json({ resultCode: "502", msg: "서버 연결 실패", data: {} }, { status: 502 });
   }

--- a/apps/admin/app/lib/api-proxy.ts
+++ b/apps/admin/app/lib/api-proxy.ts
@@ -69,11 +69,23 @@ async function buildProxyResponse(res: Response) {
     );
   }
 
-  if (res.status === 204 || res.headers.get("content-length") === "0") {
-    return NextResponse.json({ resultCode: "200", msg: "success", data: {} }, { status: res.status });
+  const text = await res.text();
+  if (!text) {
+    return NextResponse.json(
+      { resultCode: String(res.status), msg: "success", data: {} },
+      { status: res.status },
+    );
   }
-  const data = await res.json();
-  return NextResponse.json(data, { status: res.status });
+
+  try {
+    const data = JSON.parse(text);
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json(
+      { resultCode: String(res.status), msg: "서버에서 잘못된 응답을 받았습니다", data: {} },
+      { status: res.status },
+    );
+  }
 }
 
 export async function apiProxy(

--- a/apps/admin/app/lib/api-proxy.ts
+++ b/apps/admin/app/lib/api-proxy.ts
@@ -3,16 +3,16 @@ import { getAccessToken, getRefreshToken, setAuthCookies, clearAuthCookies } fro
 
 const API_URL = process.env.API_URL;
 
-let refreshPromise: Promise<boolean> | null = null;
+let refreshPromise: Promise<string | null> | null = null;
 
-async function tryRefresh(): Promise<boolean> {
+async function tryRefresh(): Promise<string | null> {
   if (refreshPromise) return refreshPromise;
 
   refreshPromise = (async () => {
     const refreshToken = await getRefreshToken();
     if (!refreshToken) {
       await clearAuthCookies();
-      return false;
+      return null;
     }
 
     try {
@@ -24,15 +24,15 @@ async function tryRefresh(): Promise<boolean> {
 
       if (!res.ok) {
         await clearAuthCookies();
-        return false;
+        return null;
       }
 
       const data = await res.json();
       await setAuthCookies(data.data.accessToken, data.data.refreshToken);
-      return true;
+      return data.data.accessToken as string;
     } catch {
       await clearAuthCookies();
-      return false;
+      return null;
     }
   })().finally(() => {
     refreshPromise = null;
@@ -41,18 +41,20 @@ async function tryRefresh(): Promise<boolean> {
   return refreshPromise;
 }
 
-async function sendWithAuth(path: string, init: RequestInit): Promise<Response> {
-  const accessToken = await getAccessToken();
+async function sendWithAuth(path: string, init: RequestInit, overrideToken?: string): Promise<Response> {
+  const accessToken = overrideToken ?? (await getAccessToken());
   const headers = new Headers(init.headers);
   if (accessToken) headers.set("Authorization", `Bearer ${accessToken}`);
   return fetch(`${API_URL}${path}`, { ...init, headers });
 }
 
-async function withAutoRefresh(execute: () => Promise<Response>): Promise<Response> {
+async function withAutoRefresh(
+  execute: (overrideToken?: string) => Promise<Response>,
+): Promise<Response> {
   let res = await execute();
   if (res.status === 401) {
-    const refreshed = await tryRefresh();
-    if (refreshed) res = await execute();
+    const newToken = await tryRefresh();
+    if (newToken) res = await execute(newToken);
   }
   return res;
 }
@@ -86,8 +88,8 @@ export async function apiProxy(
       : undefined;
 
   try {
-    const res = await withAutoRefresh(() =>
-      sendWithAuth(path, { method, headers, body: serializedBody }),
+    const res = await withAutoRefresh((token) =>
+      sendWithAuth(path, { method, headers, body: serializedBody }, token),
     );
     return buildProxyResponse(res);
   } catch {

--- a/apps/admin/proxy.ts
+++ b/apps/admin/proxy.ts
@@ -3,11 +3,32 @@ import type { NextRequest } from "next/server";
 
 const PUBLIC_PATHS = ["/login"];
 
-export function proxy(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const accessToken = request.cookies.get("admin_access_token")?.value;
+  const refreshToken = request.cookies.get("admin_refresh_token")?.value;
 
   const isPublicPath = PUBLIC_PATHS.some((path) => pathname === path || pathname.startsWith(path + "/"));
+
+  if (!accessToken && refreshToken && !isPublicPath) {
+    try {
+      const refreshRes = await fetch(new URL("/api/auth/refresh", request.url), {
+        method: "POST",
+        headers: { cookie: request.headers.get("cookie") ?? "" },
+      });
+
+      if (refreshRes.ok) {
+        const response = NextResponse.next();
+        const setCookieHeaders = refreshRes.headers.getSetCookie?.() ?? [];
+        for (const cookie of setCookieHeaders) {
+          response.headers.append("set-cookie", cookie);
+        }
+        return response;
+      }
+    } catch {
+      // fall through
+    }
+  }
 
   if (!accessToken && !isPublicPath) {
     const loginUrl = new URL("/login", request.url);

--- a/apps/home/app/lib/api-proxy.ts
+++ b/apps/home/app/lib/api-proxy.ts
@@ -3,18 +3,19 @@ import { getAccessToken, getRefreshToken, setAuthCookies, clearAuthCookies } fro
 
 const API_URL = process.env.API_URL;
 
-let refreshPromise: Promise<string | null> | null = null;
+const refreshPromises = new Map<string, Promise<string | null>>();
 
 async function tryRefresh(): Promise<string | null> {
-  if (refreshPromise) return refreshPromise;
+  const refreshToken = await getRefreshToken();
+  if (!refreshToken) {
+    await clearAuthCookies();
+    return null;
+  }
 
-  refreshPromise = (async () => {
-    const refreshToken = await getRefreshToken();
-    if (!refreshToken) {
-      await clearAuthCookies();
-      return null;
-    }
+  const existing = refreshPromises.get(refreshToken);
+  if (existing) return existing;
 
+  const promise = (async () => {
     try {
       const res = await fetch(`${API_URL}/api/v1/auth/refresh`, {
         method: "POST",
@@ -35,10 +36,11 @@ async function tryRefresh(): Promise<string | null> {
       return null;
     }
   })().finally(() => {
-    refreshPromise = null;
+    refreshPromises.delete(refreshToken);
   });
 
-  return refreshPromise;
+  refreshPromises.set(refreshToken, promise);
+  return promise;
 }
 
 async function sendWithAuth(path: string, init: RequestInit, overrideToken?: string): Promise<Response> {
@@ -66,6 +68,7 @@ async function buildProxyResponse(res: Response) {
       { status: 401 },
     );
   }
+
   if (res.status === 204 || res.headers.get("content-length") === "0") {
     return NextResponse.json({ resultCode: "200", msg: "success", data: {} }, { status: res.status });
   }

--- a/apps/home/app/lib/api-proxy.ts
+++ b/apps/home/app/lib/api-proxy.ts
@@ -1,58 +1,106 @@
 import { NextResponse } from "next/server";
-import { getAccessToken } from "./auth-cookies";
+import { getAccessToken, getRefreshToken, setAuthCookies, clearAuthCookies } from "./auth-cookies";
 
 const API_URL = process.env.API_URL;
+
+let refreshPromise: Promise<boolean> | null = null;
+
+async function tryRefresh(): Promise<boolean> {
+  if (refreshPromise) return refreshPromise;
+
+  refreshPromise = (async () => {
+    const refreshToken = await getRefreshToken();
+    if (!refreshToken) {
+      await clearAuthCookies();
+      return false;
+    }
+
+    try {
+      const res = await fetch(`${API_URL}/api/v1/auth/refresh`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken }),
+      });
+
+      if (!res.ok) {
+        await clearAuthCookies();
+        return false;
+      }
+
+      const data = await res.json();
+      await setAuthCookies(data.data.accessToken, data.data.refreshToken);
+      return true;
+    } catch {
+      await clearAuthCookies();
+      return false;
+    }
+  })().finally(() => {
+    refreshPromise = null;
+  });
+
+  return refreshPromise;
+}
+
+async function sendWithAuth(path: string, init: RequestInit): Promise<Response> {
+  const accessToken = await getAccessToken();
+  const headers = new Headers(init.headers);
+  if (accessToken) headers.set("Authorization", `Bearer ${accessToken}`);
+  return fetch(`${API_URL}${path}`, { ...init, headers });
+}
+
+async function withAutoRefresh(execute: () => Promise<Response>): Promise<Response> {
+  let res = await execute();
+  if (res.status === 401) {
+    const refreshed = await tryRefresh();
+    if (refreshed) res = await execute();
+  }
+  return res;
+}
+
+async function buildProxyResponse(res: Response) {
+  if (res.status === 401) {
+    return NextResponse.json(
+      { resultCode: "401", msg: "세션이 만료되었습니다", data: {} },
+      { status: 401 },
+    );
+  }
+  if (res.status === 204 || res.headers.get("content-length") === "0") {
+    return NextResponse.json({ resultCode: "200", msg: "success", data: {} }, { status: res.status });
+  }
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}
 
 export async function apiProxy(
   path: string,
   options: { method?: string; body?: unknown; contentType?: string } = {},
 ) {
-  const accessToken = await getAccessToken();
   const { method = "GET", body, contentType } = options;
-
   const headers: Record<string, string> = {};
-  if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
   if (contentType) headers["Content-Type"] = contentType;
+  const serializedBody =
+    body !== undefined
+      ? typeof body === "string"
+        ? body
+        : JSON.stringify(body)
+      : undefined;
 
   try {
-    const res = await fetch(`${API_URL}${path}`, {
-      method,
-      headers,
-      body: body !== undefined
-        ? typeof body === "string" ? body : JSON.stringify(body)
-        : undefined,
-    });
-
-    if (res.status === 204 || res.headers.get("content-length") === "0") {
-      return NextResponse.json({ resultCode: "200", msg: "success", data: {} }, { status: res.status });
-    }
-
-    const data = await res.json();
-    return NextResponse.json(data, { status: res.status });
+    const res = await withAutoRefresh(() =>
+      sendWithAuth(path, { method, headers, body: serializedBody }),
+    );
+    return buildProxyResponse(res);
   } catch {
     return NextResponse.json({ resultCode: "502", msg: "서버 연결 실패", data: {} }, { status: 502 });
   }
 }
 
 export async function apiProxyFormData(path: string, formData: FormData) {
-  const accessToken = await getAccessToken();
-
-  const headers: Record<string, string> = {};
-  if (accessToken) headers["Authorization"] = `Bearer ${accessToken}`;
-
   try {
-    const res = await fetch(`${API_URL}${path}`, {
-      method: "POST",
-      headers,
-      body: formData,
-    });
-
-    if (res.status === 204 || res.headers.get("content-length") === "0") {
-      return NextResponse.json({ resultCode: "200", msg: "success", data: {} }, { status: res.status });
-    }
-
-    const data = await res.json();
-    return NextResponse.json(data, { status: res.status });
+    const res = await withAutoRefresh(() =>
+      sendWithAuth(path, { method: "POST", body: formData }),
+    );
+    return buildProxyResponse(res);
   } catch {
     return NextResponse.json({ resultCode: "502", msg: "서버 연결 실패", data: {} }, { status: 502 });
   }

--- a/apps/home/app/lib/api-proxy.ts
+++ b/apps/home/app/lib/api-proxy.ts
@@ -69,11 +69,23 @@ async function buildProxyResponse(res: Response) {
     );
   }
 
-  if (res.status === 204 || res.headers.get("content-length") === "0") {
-    return NextResponse.json({ resultCode: "200", msg: "success", data: {} }, { status: res.status });
+  const text = await res.text();
+  if (!text) {
+    return NextResponse.json(
+      { resultCode: String(res.status), msg: "success", data: {} },
+      { status: res.status },
+    );
   }
-  const data = await res.json();
-  return NextResponse.json(data, { status: res.status });
+
+  try {
+    const data = JSON.parse(text);
+    return NextResponse.json(data, { status: res.status });
+  } catch {
+    return NextResponse.json(
+      { resultCode: String(res.status), msg: "서버에서 잘못된 응답을 받았습니다", data: {} },
+      { status: res.status },
+    );
+  }
 }
 
 export async function apiProxy(

--- a/apps/home/app/lib/api-proxy.ts
+++ b/apps/home/app/lib/api-proxy.ts
@@ -3,16 +3,16 @@ import { getAccessToken, getRefreshToken, setAuthCookies, clearAuthCookies } fro
 
 const API_URL = process.env.API_URL;
 
-let refreshPromise: Promise<boolean> | null = null;
+let refreshPromise: Promise<string | null> | null = null;
 
-async function tryRefresh(): Promise<boolean> {
+async function tryRefresh(): Promise<string | null> {
   if (refreshPromise) return refreshPromise;
 
   refreshPromise = (async () => {
     const refreshToken = await getRefreshToken();
     if (!refreshToken) {
       await clearAuthCookies();
-      return false;
+      return null;
     }
 
     try {
@@ -24,15 +24,15 @@ async function tryRefresh(): Promise<boolean> {
 
       if (!res.ok) {
         await clearAuthCookies();
-        return false;
+        return null;
       }
 
       const data = await res.json();
       await setAuthCookies(data.data.accessToken, data.data.refreshToken);
-      return true;
+      return data.data.accessToken as string;
     } catch {
       await clearAuthCookies();
-      return false;
+      return null;
     }
   })().finally(() => {
     refreshPromise = null;
@@ -41,18 +41,20 @@ async function tryRefresh(): Promise<boolean> {
   return refreshPromise;
 }
 
-async function sendWithAuth(path: string, init: RequestInit): Promise<Response> {
-  const accessToken = await getAccessToken();
+async function sendWithAuth(path: string, init: RequestInit, overrideToken?: string): Promise<Response> {
+  const accessToken = overrideToken ?? (await getAccessToken());
   const headers = new Headers(init.headers);
   if (accessToken) headers.set("Authorization", `Bearer ${accessToken}`);
   return fetch(`${API_URL}${path}`, { ...init, headers });
 }
 
-async function withAutoRefresh(execute: () => Promise<Response>): Promise<Response> {
+async function withAutoRefresh(
+  execute: (overrideToken?: string) => Promise<Response>,
+): Promise<Response> {
   let res = await execute();
   if (res.status === 401) {
-    const refreshed = await tryRefresh();
-    if (refreshed) res = await execute();
+    const newToken = await tryRefresh();
+    if (newToken) res = await execute(newToken);
   }
   return res;
 }
@@ -86,8 +88,8 @@ export async function apiProxy(
       : undefined;
 
   try {
-    const res = await withAutoRefresh(() =>
-      sendWithAuth(path, { method, headers, body: serializedBody }),
+    const res = await withAutoRefresh((token) =>
+      sendWithAuth(path, { method, headers, body: serializedBody }, token),
     );
     return buildProxyResponse(res);
   } catch {
@@ -97,8 +99,8 @@ export async function apiProxy(
 
 export async function apiProxyFormData(path: string, formData: FormData) {
   try {
-    const res = await withAutoRefresh(() =>
-      sendWithAuth(path, { method: "POST", body: formData }),
+    const res = await withAutoRefresh((token) =>
+      sendWithAuth(path, { method: "POST", body: formData }, token),
     );
     return buildProxyResponse(res);
   } catch {

--- a/apps/home/proxy.ts
+++ b/apps/home/proxy.ts
@@ -11,12 +11,33 @@ function matches(pathname: string, paths: string[]) {
   return paths.some((path) => pathname === path || pathname.startsWith(path + "/"));
 }
 
-export function proxy(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const accessToken = request.cookies.get("student_access_token")?.value;
+  const refreshToken = request.cookies.get("student_refresh_token")?.value;
 
   const isPublic = matches(pathname, PUBLIC_PATHS);
   const isGuestOnly = matches(pathname, GUEST_ONLY_PATHS);
+
+  if (!accessToken && refreshToken && !isGuestOnly) {
+    try {
+      const refreshRes = await fetch(new URL("/api/auth/refresh", request.url), {
+        method: "POST",
+        headers: { cookie: request.headers.get("cookie") ?? "" },
+      });
+
+      if (refreshRes.ok) {
+        const response = NextResponse.next();
+        const setCookieHeaders = refreshRes.headers.getSetCookie?.() ?? [];
+        for (const cookie of setCookieHeaders) {
+          response.headers.append("set-cookie", cookie);
+        }
+        return response;
+      }
+    } catch {
+      // fall through
+    }
+  }
 
   if (accessToken && isGuestOnly) {
     return NextResponse.redirect(new URL("/", request.url));

--- a/packages/api/src/query-client.ts
+++ b/packages/api/src/query-client.ts
@@ -21,7 +21,10 @@ export function createQueryClient() {
     defaultOptions: {
       queries: {
         staleTime: 60 * 1000,
-        retry: 1,
+        retry: (failureCount, error) => {
+          if (error instanceof ApiError && error.status === 401) return false;
+          return failureCount < 1;
+        },
         refetchOnWindowFocus: false,
       },
     },

--- a/packages/api/src/query-client.ts
+++ b/packages/api/src/query-client.ts
@@ -1,7 +1,23 @@
-import { QueryClient } from "@tanstack/react-query";
+"use client";
+
+import { QueryClient, QueryCache, MutationCache } from "@tanstack/react-query";
+import { ApiError } from "./client";
+
+function handleGlobalError(error: unknown) {
+  if (
+    error instanceof ApiError &&
+    error.status === 401 &&
+    typeof window !== "undefined" &&
+    !window.location.pathname.startsWith("/login")
+  ) {
+    window.location.href = "/login";
+  }
+}
 
 export function createQueryClient() {
   return new QueryClient({
+    queryCache: new QueryCache({ onError: handleGlobalError }),
+    mutationCache: new MutationCache({ onError: handleGlobalError }),
     defaultOptions: {
       queries: {
         staleTime: 60 * 1000,


### PR DESCRIPTION
## 연관 Issue
- closes #32

## 요약
외부 API가 401을 반환했을 때 BFF가 투명하게 refresh 후 원요청을 재시도하는 흐름을 추가했습니다. 동시 다중 요청의 race도 해소했고, 최종 실패 시 클라이언트는 자동으로 `/login`으로 이동합니다.

## 변경 사항
- `apps/home/app/lib/api-proxy.ts` · `apps/admin/app/lib/api-proxy.ts`
  - `tryRefresh()`: 모듈 레벨 promise dedup, 내부 `/api/v1/auth/refresh` 호출, 성공 시 쿠키 갱신 후 새 access token 반환
  - `sendWithAuth()`: override 토큰이 있으면 그걸 Bearer로 사용, 없으면 쿠키에서 읽음
  - `withAutoRefresh()`: 401 수신 시 refresh 후 새 토큰으로 재시도 (동시 요청도 같은 토큰 공유)
  - refresh 실패 시 쿠키 정리 + 401 엔벨로프 반환
- `packages/api/src/query-client.ts`
  - `QueryCache` / `MutationCache`의 `onError`에서 `ApiError.status === 401` 감지 시 `/login` 이동
  - `retry`를 함수로 바꿔 401은 재시도 제외

## 범위
### 포함:
- BFF 자동 재발급 + 재시도
- 동시 요청 race 방지 (공유 promise + override 토큰 전달)
- 클라이언트 전역 401 처리 (/login 이동)
- 홈·관리자 앱 동일 적용

### 제외:
- 외부 API 호출 경로 외부에서의 401 (예: 로그인 실패 등)은 해당 mutation의 onError로 계속 처리